### PR TITLE
Fix rowMajorAssay to maintain value order

### DIFF
--- a/src/ISADotnet/JsonIO/AssayCommonAPI.fs
+++ b/src/ISADotnet/JsonIO/AssayCommonAPI.fs
@@ -48,7 +48,9 @@ module AssayCommonAPI =
             ||> List.map2 (fun inp out ->
                 let inpCharacteristics = API.ProcessInput.tryGetCharacteristics inp |> Option.defaultValue []
                 let outCharacteristics = API.ProcessOutput.tryGetCharacteristics out |> Option.defaultValue []
-                let characteristics = Set.intersect (set inpCharacteristics) (set outCharacteristics) |> Set.toList
+                let characteristics = 
+                    let s = Set.intersect (set inpCharacteristics) (set outCharacteristics)
+                    inpCharacteristics |> List.filter (s.Contains)
                 let factors = API.ProcessOutput.tryGetFactorValues out |> Option.defaultValue []
 
                 let inputName = inp.GetName


### PR DESCRIPTION
When writing files to `rowMajorAssay` files, the order of `parameters`, `factors` and `characteristics` is lost. This commit fixes this.