### PR TITLE
Bugfixes and minor improvements

### DIFF
--- a/src/ISADotNet.Viz/DAG.fs
+++ b/src/ISADotNet.Viz/DAG.fs
@@ -25,6 +25,7 @@ type DAG =
                 p.Outputs.Value
                 |> List.zip p.Inputs.Value
                 |> List.map (fun (i,o) -> ProcessInput.getName i ,ProcessOutput.getName o ,p.Name.Value)
+                |> List.distinct
             )
             |> List.append (rootNodes |> List.map (fun i -> "Root",i,""))
                           

--- a/src/ISADotNet.XLSX/AssayFile/AnnotationColumn.fs
+++ b/src/ISADotNet.XLSX/AssayFile/AnnotationColumn.fs
@@ -31,8 +31,8 @@ module AnnotationColumn =
         /// Parses a string to a column header
         static member fromStringHeader header =
                   
-            let kindPattern = @".*(?= [\[\(])"
-            let namePattern = @"(?<= \[)[^#\]]*(?=[\]#])"
+            let kindPattern = @"[^\[(]*(?= [\[\(])"
+            let namePattern = @"(?<= \[).*(?=[\]])"
             let ontologySourcePattern = @"(?<=\()\S+:[^;)#]*(?=[\)\#])"
             let numberPattern = @"(?<=#)\d+(?=[\)\]])"
 

--- a/src/ISADotNet.XLSX/AssayFile/AnnotationColumn.fs
+++ b/src/ISADotNet.XLSX/AssayFile/AnnotationColumn.fs
@@ -10,6 +10,16 @@ module AnnotationColumn =
     [<Literal>]
     let OboPurlURL = @"http://purl.obolibrary.org/obo/"
 
+    module RegexPattern =
+
+        // Pattern matches start of line and then any number of characters except newline, open bracket and open curly bracket.
+        let columnTypePattern = @"^[^[(\n]*" //@"[^\[(]*(?= [\[\(])"
+        let namePattern = @"(?<= \[).*(?=[\]])"
+        // [\w-]+ = Pattern matches any letter, number, underscore and minus, but minimum 1
+        // (:|_) = ':' or '_', latter is important for url
+        let ontologySourcePattern = "[\w-]+(:|_)[\w-]+"//@"(?<=\()\S+:[^;)#]*(?=[\)\#])"
+        let numberPattern = @"(?<=#)\d+(?=[\)\]])"
+
     /// Typed depiction of a Swate Header: Kind [TermName] (#Number, #tOntology)
     type ColumnHeader =
         {
@@ -31,15 +41,10 @@ module AnnotationColumn =
         /// Parses a string to a column header
         static member fromStringHeader header =
                   
-            let kindPattern = @"[^\[(]*(?= [\[\(])"
-            let namePattern = @"(?<= \[).*(?=[\]])"
-            let ontologySourcePattern = @"(?<=\()\S+:[^;)#]*(?=[\)\#])"
-            let numberPattern = @"(?<=#)\d+(?=[\)\]])"
-
-            let nameRegex = Regex.Match(header,namePattern)
-            let kindRegex = Regex.Match(header,kindPattern)
-            let ontologySourceRegex = Regex.Match(header,ontologySourcePattern)
-            let numberRegex = Regex.Match(header,numberPattern)
+            let nameRegex = Regex.Match(header,RegexPattern.namePattern)
+            let columnTypePatternRegex = Regex.Match(header,RegexPattern.columnTypePattern)
+            let ontologySourceRegex = Regex.Match(header,RegexPattern.ontologySourcePattern)
+            let numberRegex = Regex.Match(header,RegexPattern.numberPattern)
 
             let number = if numberRegex.Success then Some (int numberRegex.Value) else None
             let numberComment = number |> Option.map (string >> (Comment.fromString "Number") >> List.singleton)
@@ -49,11 +54,11 @@ module AnnotationColumn =
                                                                              
                 let ontology = OntologyAnnotation.fromString nameRegex.Value "" ""
 
-                ColumnHeader.create header kindRegex.Value (Some {ontology with Comments = numberComment}) number
+                ColumnHeader.create header (columnTypePatternRegex.Value.Trim()) (Some {ontology with Comments = numberComment}) number
 
             // Parsing a header of shape: Kind (#Number)
-            elif kindRegex.Success then
-                let kind = kindRegex.Value
+            elif columnTypePatternRegex.Success then
+                let kind = (columnTypePatternRegex.Value.Trim())
 
                 let ontology = 
                     if ontologySourceRegex.Success then 

--- a/src/ISADotNet.XLSX/AssayFile/Assay.fs
+++ b/src/ISADotNet.XLSX/AssayFile/Assay.fs
@@ -65,9 +65,16 @@ module Assay =
                 Seq.append processes' processes
             ) (List.empty,List.empty,Seq.empty,Seq.empty)
 
-        let processes = AnnotationTable.updateSamplesByThemselves processes
+        let processes = AnnotationTable.updateSamplesByThemselves processes |> Seq.toList
 
-        factors,protocols,Assay.create(CharacteristicCategories = characteristics,ProcessSequence = Seq.toList processes)
+        let assay = 
+            match characteristics,processes with
+            | [],[] -> Assay.create()
+            | [],ps -> Assay.create(ProcessSequence = ps)
+            | cs,[] -> Assay.create(CharacteristicCategories = cs)
+            | cs,ps -> Assay.create(CharacteristicCategories = cs,ProcessSequence = ps)
+
+        factors,protocols,assay
 
 /// Diesen Block durch JS ersetzen ----> 
 

--- a/src/ISADotNet.XLSX/AssayFile/Assay.fs
+++ b/src/ISADotNet.XLSX/AssayFile/Assay.fs
@@ -101,16 +101,17 @@ module Assay =
 
             // Reading the "Assay" metadata sheet. Here metadata 
             let assayMetaData,contacts = 
-                Spreadsheet.tryGetSheetBySheetName "Assay" doc
-                |> Option.map (fun sheet -> 
+                match Spreadsheet.tryGetSheetBySheetName "Assay" doc with 
+                | Some sheet ->
                     sheet
                     |> SheetData.getRows
                     |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
                     |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
                     |> MetaData.fromRows
                     |> fun (a,p) -> Option.defaultValue Assay.empty a, p
-                )
-                |> Option.defaultValue (Assay.empty,[])          
+                | None -> 
+                    printfn "Cannot retrieve metadata: Assay file does not contain \"Assay\" sheet."
+                    Assay.empty,[]         
         
             // All sheetnames in the spreadsheetDocument
             let sheetNames = 

--- a/src/ISADotNet.XLSX/AssayFile/Assay.fs
+++ b/src/ISADotNet.XLSX/AssayFile/Assay.fs
@@ -48,8 +48,11 @@ module Assay =
     ///
     /// sparseMatrix is a sparse representation of the sheet table, with the first part of the key being the column header and the second part being a zero based row index
     let fromSparseMatrix (processNameRoot:string) matrixHeaders (sparseMatrix : Dictionary<int*string,string>) = 
-        let characteristics,factors,protocols,processes = Process.fromSparseMatrix processNameRoot matrixHeaders sparseMatrix
-        factors,protocols,Assay.create(CharacteristicCategories = characteristics,ProcessSequence = Seq.toList processes)
+        try 
+            let characteristics,factors,protocols,processes = Process.fromSparseMatrix processNameRoot matrixHeaders sparseMatrix
+            factors,protocols,Assay.create(CharacteristicCategories = characteristics,ProcessSequence = Seq.toList processes)
+        with
+        | err -> failwithf "Could not parse sheet \"%s\": %s" processNameRoot err.Message
 
     /// Returns an assay from a sequence of sparseMatrix representations of assay.xlsx sheets
     ///
@@ -80,9 +83,12 @@ module Assay =
 
     /// Create a new ISADotNet.XLSX assay file constisting of two sheets. The first has the name of the assayIdentifier and is meant to store parameters used in the assay. The second stores additional assay metadata
     let init assay persons assayIdentifier path =
-        Spreadsheet.initWithSst assayIdentifier path
-        |> MetaData.init "Assay" assay persons
-        |> Spreadsheet.close
+        try 
+            Spreadsheet.initWithSst assayIdentifier path
+            |> MetaData.init "Assay" assay persons
+            |> Spreadsheet.close
+        with
+        | err -> failwithf "Could not init assay file: %s" err.Message
 
     /// Reads an assay from an xlsx spreadsheetdocument
     ///
@@ -90,67 +96,73 @@ module Assay =
     ///
     /// The persons from the metadata sheet are returned independently as they are not a part of the assay object
     let fromSpreadsheet (doc:DocumentFormat.OpenXml.Packaging.SpreadsheetDocument) = 
-        
-        let sst = Spreadsheet.tryGetSharedStringTable doc
+        try
+            let sst = Spreadsheet.tryGetSharedStringTable doc
 
-        // Reading the "Assay" metadata sheet. Here metadata 
-        let assayMetaData,contacts = 
-            Spreadsheet.tryGetSheetBySheetName "Assay" doc
-            |> Option.map (fun sheet -> 
-                sheet
-                |> SheetData.getRows
-                |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
-                |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
-                |> MetaData.fromRows
-                |> fun (a,p) -> Option.defaultValue Assay.empty a, p
-            )
-            |> Option.defaultValue (Assay.empty,[])          
+            // Reading the "Assay" metadata sheet. Here metadata 
+            let assayMetaData,contacts = 
+                Spreadsheet.tryGetSheetBySheetName "Assay" doc
+                |> Option.map (fun sheet -> 
+                    sheet
+                    |> SheetData.getRows
+                    |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
+                    |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
+                    |> MetaData.fromRows
+                    |> fun (a,p) -> Option.defaultValue Assay.empty a, p
+                )
+                |> Option.defaultValue (Assay.empty,[])          
         
-        // All sheetnames in the spreadsheetDocument
-        let sheetNames = 
-            Spreadsheet.getWorkbookPart doc
-            |> Workbook.get
-            |> Sheet.Sheets.get
-            |> Sheet.Sheets.getSheets
-            |> Seq.map Sheet.getName
+            // All sheetnames in the spreadsheetDocument
+            let sheetNames = 
+                Spreadsheet.getWorkbookPart doc
+                |> Workbook.get
+                |> Sheet.Sheets.get
+                |> Sheet.Sheets.getSheets
+                |> Seq.map Sheet.getName
         
-        let factors,protocols,assay =
-            sheetNames
-            |> Seq.collect (fun sheetName ->                    
-                match Spreadsheet.tryGetWorksheetPartBySheetName sheetName doc with
-                | Some wsp ->
-                    match Table.tryGetByNameBy (fun s -> s.StartsWith "annotationTable") wsp with
-                    | Some table -> 
-                        // Extract the sheetdata as a sparse matrix
-                        let sheet = Worksheet.getSheetData wsp.Worksheet
-                        let headers = Table.getColumnHeaders table
-                        let m = Table.toSparseValueMatrix sst sheet table
-                        Seq.singleton (sheetName,headers,m)     
-                    | None -> Seq.empty
-                | None -> Seq.empty                
-            )
-            |> fromSparseMatrices // Feed the sheets (represented as sparse matrices) into the assay parser function
+            let factors,protocols,assay =
+                sheetNames
+                |> Seq.collect (fun sheetName ->                    
+                    match Spreadsheet.tryGetWorksheetPartBySheetName sheetName doc with
+                    | Some wsp ->
+                        match Table.tryGetByNameBy (fun s -> s.StartsWith "annotationTable") wsp with
+                        | Some table -> 
+                            // Extract the sheetdata as a sparse matrix
+                            let sheet = Worksheet.getSheetData wsp.Worksheet
+                            let headers = Table.getColumnHeaders table
+                            let m = Table.toSparseValueMatrix sst sheet table
+                            Seq.singleton (sheetName,headers,m)     
+                        | None -> Seq.empty
+                    | None -> Seq.empty                
+                )
+                |> fromSparseMatrices // Feed the sheets (represented as sparse matrices) into the assay parser function
             
-        factors,
-        protocols |> Seq.toList,
-        contacts,
-        API.Update.UpdateByExisting.updateRecordType assayMetaData assay // Merges the assay containing the assay meta data and the assay containing the processes retrieved from the sheets
+            factors,
+            protocols |> Seq.toList,
+            contacts,
+            API.Update.UpdateByExisting.updateRecordType assayMetaData assay // Merges the assay containing the assay meta data and the assay containing the processes retrieved from the sheets
+        with
+        | err -> failwithf "Could not read assay from spreadsheet: %s" err.Message
 
     /// Parses the assay file
     let fromFile (path:string) = 
-        let doc = Spreadsheet.fromFile path false
         try
-            fromSpreadsheet doc
-        finally
-            Spreadsheet.close doc
-
+            let doc = Spreadsheet.fromFile path false
+            try
+                fromSpreadsheet doc
+            finally
+                Spreadsheet.close doc
+        with
+        | err -> failwithf "Could not read assay from file with path \"%s\": %s" path err.Message
+    
     /// Parses the assay file
     let fromStream (stream:#System.IO.Stream) = 
-
-        let doc = Spreadsheet.fromStream stream false
         try
-            fromSpreadsheet doc
-        finally
-            Spreadsheet.close doc
-
+            let doc = Spreadsheet.fromStream stream false
+            try
+                fromSpreadsheet doc
+            finally
+                Spreadsheet.close doc
+        with
+        | err -> failwithf "Could not read assay from stream: %s" err.Message
     /// ---->  Bis hier

--- a/src/ISADotNet.XLSX/AssayFile/Assay.fs
+++ b/src/ISADotNet.XLSX/AssayFile/Assay.fs
@@ -99,13 +99,19 @@ module Assay =
         try
             let sst = Spreadsheet.tryGetSharedStringTable doc
 
+            let tryIncludeSST sst cell = 
+                try 
+                    Cell.includeSharedStringValue (Option.get sst) cell
+                with | _ -> cell
+
+
             // Reading the "Assay" metadata sheet. Here metadata 
             let assayMetaData,contacts = 
                 match Spreadsheet.tryGetSheetBySheetName "Assay" doc with 
                 | Some sheet ->
                     sheet
                     |> SheetData.getRows
-                    |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
+                    |> Seq.map (Row.mapCells (tryIncludeSST sst))
                     |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
                     |> MetaData.fromRows
                     |> fun (a,p) -> Option.defaultValue Assay.empty a, p

--- a/src/ISADotNet.XLSX/ISADotNet.XLSX.fsproj
+++ b/src/ISADotNet.XLSX/ISADotNet.XLSX.fsproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet.ExcelIO" Version="0.0.2" />
+    <PackageReference Include="FsSpreadsheet.ExcelIO" Version="0.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
+++ b/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
@@ -202,56 +202,71 @@ module Investigation =
         |> Seq.choose id
         |> Row.create rowIndex spans 
 
-    let fromSpreadsheet (doc:DocumentFormat.OpenXml.Packaging.SpreadsheetDocument) =           
-        doc
-        |> Spreadsheet.getRowsBySheetIndex 0u
-        |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
-        |> fromRows 
-        
+    let fromSpreadsheet (doc:DocumentFormat.OpenXml.Packaging.SpreadsheetDocument) =  
+        try
+            doc
+            |> Spreadsheet.getRowsBySheetIndex 0u
+            |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
+            |> fromRows 
+        with
+        | err -> failwithf "Could not read investigation from spreadsheet: %s" err.Message
 
     let fromFile (path : string) =
-        let doc = Spreadsheet.fromFile path false
         try
-            fromSpreadsheet doc
-        finally
-            doc.Close()
-        
-    let fromStream (stream : System.IO.Stream) =
-        let doc = Spreadsheet.fromStream stream false
-        try
-            fromSpreadsheet doc
-        finally
-            doc.Close()
+            let doc = Spreadsheet.fromFile path false
+            try
+                fromSpreadsheet doc
+            finally
+                doc.Close()
+        with
+        | err -> failwithf "Could not read investigation from file with path \"%s\": %s" path err.Message
 
+    let fromStream (stream : System.IO.Stream) =
+        try
+            let doc = Spreadsheet.fromStream stream false
+            try
+                fromSpreadsheet doc
+            finally
+                doc.Close()
+        with
+        | err -> failwithf "Could not read investion from stream: %s" err.Message
 
     let toSpreadsheet (doc:DocumentFormat.OpenXml.Packaging.SpreadsheetDocument) (investigation:Investigation) =           
-        
-        let sheet = Spreadsheet.tryGetSheetBySheetIndex 0u doc |> Option.get
-
-        investigation
-        |> toRows
-        |> Seq.mapi (fun i row -> 
-            row
-            |> SparseRow.getAllValues
-            |> ofSparseValues (i+1 |> uint)
-            )
-        |> Seq.fold (fun s r -> 
-            SheetData.appendRow r s
-        ) sheet
-        |> ignore
-        
-    let toFile (path : string) (investigation:Investigation) =
-        let doc = Spreadsheet.initWithSst "isa_investigation" path
-        try 
-            toSpreadsheet doc investigation
-        finally
-            doc.Close()
-        
-    let toStream (stream : System.IO.Stream) (investigation:Investigation) =
-        let doc = Spreadsheet.fromStream stream false
         try
-            toSpreadsheet doc investigation
-        finally
-            doc.Close()
+            let sheet = Spreadsheet.tryGetSheetBySheetIndex 0u doc |> Option.get
+
+            investigation
+            |> toRows
+            |> Seq.mapi (fun i row -> 
+                row
+                |> SparseRow.getAllValues
+                |> ofSparseValues (i+1 |> uint)
+                )
+            |> Seq.fold (fun s r -> 
+                SheetData.appendRow r s
+            ) sheet
+            |> ignore
+        with
+        | err -> failwithf "Could not write investigation to spreadsheet: %s" err.Message
+
+    let toFile (path : string) (investigation:Investigation) =
+        try
+            let doc = Spreadsheet.initWithSst "isa_investigation" path
+            try 
+                toSpreadsheet doc investigation
+            finally
+                doc.Close()
+        with
+        | err -> failwithf "Could not write investigation to file with path \"%s\": %s" path err.Message
+
+    let toStream (stream : System.IO.Stream) (investigation:Investigation) =
+        try
+            let doc = Spreadsheet.fromStream stream false
+            try
+                toSpreadsheet doc investigation
+            finally
+                doc.Close()
+        with
+        | err -> failwithf "Could not write investion to stream: %s" err.Message
 
     /// ---->  Bis hier

--- a/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
+++ b/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
@@ -1,6 +1,6 @@
 namespace ISADotNet.XLSX
 open DocumentFormat.OpenXml.Spreadsheet
-open FsSpreadsheet.ExcelIO
+open FSharpSpreadsheetML
 open ISADotNet
 open ISADotNet.API
 open Comment
@@ -182,7 +182,7 @@ module Investigation =
             yield  SparseRow.fromValues[contactsLabel]
             yield! Contacts.toRows (Some contactsLabelPrefix) (Option.defaultValue [] investigation.Contacts)
 
-            for study in (Option.defaultValue [] investigation.Studies) do
+            for study in (Option.defaultValue [Study.empty] investigation.Studies) do
                 yield  SparseRow.fromValues[studyLabel]
                 yield! Study.toRows study
         }

--- a/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
+++ b/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
@@ -1,6 +1,6 @@
 namespace ISADotNet.XLSX
 open DocumentFormat.OpenXml.Spreadsheet
-open FSharpSpreadsheetML
+open FsSpreadsheet.ExcelIO
 open ISADotNet
 open ISADotNet.API
 open Comment

--- a/src/ISADotNet.XLSX/StudyFile/MetaData.fs
+++ b/src/ISADotNet.XLSX/StudyFile/MetaData.fs
@@ -4,37 +4,24 @@ open FsSpreadsheet.ExcelIO
 open ISADotNet
 open ISADotNet.XLSX
 
-/// Functions for reading and writing the additional information stored in the assay metadata sheet
+/// Functions for reading and writing the additional information stored in the study metadata sheet
 module MetaData =
 
     let studiesLabel = "STUDY METADATA"
 
-    /// Write Assay Metadata to excel rows
+    /// Write Study Metadata to excel rows
     let toRows (study:Study) =
         seq {          
             yield  SparseRow.fromValues [studiesLabel]
             yield! Study.toRows study
         }
         
-    /// Read Assay Metadata from excel rows
+    /// Read Study Metadata from excel rows
     let fromRows (rows: seq<SparseRow>) =
         let en = rows.GetEnumerator()
         en.MoveNext() |> ignore  
         let _,_,_,study = Study.fromRows 2 en
         study
-
-
-    ///let doc = Spreadsheet.fromFile path true  
-    ///  
-    ///MetadataSheet.overwriteWithAssayInfo "Investigation" testAssay2 doc
-    ///
-    ///MetadataSheet.overwriteWithPersons "Investigation" [person] doc
-    /// 
-    ///MetadataSheet.getPersons "Investigation" doc
-    ///
-    ///MetadataSheet.tryGetAssay "Investigation" doc
-    ///  
-    ///doc.Close()
 
     /// Diesen Block durch JS ersetzen ----> 
 
@@ -78,7 +65,7 @@ module MetaData =
         doc
 
 
-    /// Try get assay from metadatasheet with given sheetName
+    /// Try get study from metadatasheet with given sheetName
     let tryGetStudy sheetName (doc : SpreadsheetDocument) = 
         match Spreadsheet.tryGetSheetBySheetName sheetName doc with
         | Some sheet -> 
@@ -88,7 +75,7 @@ module MetaData =
             |> fromRows           
         | None -> failwithf "Metadata sheetname %s could not be found" sheetName
 
-    /// Replaces assay metadata from metadatasheet with given sheetName
+    /// Replaces study metadata from metadatasheet with given sheetName
     let overwriteWithStudyInfo sheetName study (doc : SpreadsheetDocument) = 
 
         let workBookPart = Spreadsheet.getWorkbookPart doc

--- a/src/ISADotNet.XLSX/StudyFile/Study.fs
+++ b/src/ISADotNet.XLSX/StudyFile/Study.fs
@@ -62,13 +62,18 @@ module Study =
         try
             let sst = Spreadsheet.tryGetSharedStringTable doc
 
+            let tryIncludeSST sst cell = 
+                try 
+                    Cell.includeSharedStringValue (Option.get sst) cell
+                with | _ -> cell
+
             // Reading the "Study" metadata sheet. Here metadata 
             let studyMetaData = 
                 match Spreadsheet.tryGetSheetBySheetName "Study" doc with
                 | Some sheet ->
                     sheet
                     |> SheetData.getRows
-                    |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
+                    |> Seq.map (Row.mapCells (tryIncludeSST sst))
                     |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
                     |> MetaData.fromRows
                 

--- a/src/ISADotNet.XLSX/StudyFile/Study.fs
+++ b/src/ISADotNet.XLSX/StudyFile/Study.fs
@@ -64,16 +64,17 @@ module Study =
 
             // Reading the "Study" metadata sheet. Here metadata 
             let studyMetaData = 
-                Spreadsheet.tryGetSheetBySheetName "Study" doc
-                |> Option.map (fun sheet -> 
+                match Spreadsheet.tryGetSheetBySheetName "Study" doc with
+                | Some sheet ->
                     sheet
                     |> SheetData.getRows
                     |> Seq.map (Row.mapCells (Cell.includeSharedStringValue sst.Value))
                     |> Seq.map (Row.getIndexedValues None >> Seq.map (fun (i,v) -> (int i) - 1, v))
                     |> MetaData.fromRows
                 
-                )
-                |> Option.defaultValue (Study.empty)          
+                | None -> 
+                    printfn "Cannot retrieve metadata: Study file does not contain \"Study\" sheet."
+                    Study.empty        
         
             // All sheetnames in the spreadsheetDocument
             let sheetNames = 

--- a/src/ISADotnet/API/Process.fs
+++ b/src/ISADotnet/API/Process.fs
@@ -260,21 +260,20 @@ module Process =
 
     /// If the process implements the given characteristic, return the list of output files together with their according characteristic values of this characteristic
     let tryGetOutputsWithCharacteristicBy (predicate : MaterialAttribute -> bool) (p : Process) =
-        match p.Outputs with
-        | Some os ->
-            os
-            |> List.choose (fun o ->
-                ProcessOutput.tryGetCharacteristics o
+        match  p.Inputs, p.Outputs with
+        | Some is,Some os ->
+            List.zip is os
+            |> List.choose (fun (i,o) ->
+                ProcessInput.tryGetCharacteristics i
                 |> Option.defaultValue []
                 |> List.tryPick (fun mv -> 
                     match mv.Category with
                     | Some m when predicate m -> Some (o,mv)
                     | _ -> None
-
                 )
             )
             |> Option.fromValueWithDefault []
-        | None -> None
+        | _ -> None
 
     /// Returns the factors of the samples of the process
     let getFactors (p : Process) =

--- a/src/ISADotnet/DataModel/Factor.fs
+++ b/src/ISADotnet/DataModel/Factor.fs
@@ -53,34 +53,40 @@ type Factor =
         factor.FactorType |> Option.map OntologyAnnotation.toString |> Option.defaultValue ("","","")  
 
     /// Returns the name of the factor as string
-    [<System.Obsolete("This function is deprecated. Use the member \"GetName\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.NameAsString =
         this.Name
         |> Option.defaultValue ""
 
     /// Returns the name of the factor with the number as string (e.g. "temperature #2")
-    [<System.Obsolete("This function is deprecated. Use the member \"GetNameWithNumber\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.NameAsStringWithNumber =       
         this.FactorType
         |> Option.map (fun oa -> oa.GetNameWithNumber)
         |> Option.defaultValue ""
 
     /// Returns the name of the factor as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.Name
         |> Option.defaultValue ""
 
     /// Returns the name of the factor with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =     
         this.FactorType
-        |> Option.map (fun oa -> oa.GetName)
+        |> Option.map (fun oa -> oa.NameText)
+        |> Option.defaultValue ""
+
+    member this.NameText =
+        this.Name
         |> Option.defaultValue ""
 
     interface IISAPrintable with
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            "OA " + this.GetNameWithNumber
+            "OA " + this.NameText
 
 [<AnyOf>]
 type Value =
@@ -115,7 +121,7 @@ type Value =
 
     member this.AsString =         
         match this with
-        | Value.Ontology oa  -> oa.GetName
+        | Value.Ontology oa  -> oa.NameText
         | Value.Float f -> string f
         | Value.Int i   -> string i
         | Value.Name s  -> s
@@ -125,7 +131,7 @@ type Value =
             this.ToString()
         member this.PrintCompact() =
             match this with
-            | Ontology oa   -> oa.GetName
+            | Ontology oa   -> oa.NameText
             | Int i         -> sprintf "%i" i
             | Float f       -> sprintf "%f" f        
             | Name n        -> n
@@ -156,32 +162,45 @@ type FactorValue =
     static member empty =
         FactorValue.create()
 
-    member this.GetValue =
+    member this.ValueText =
         this.Value
         |> Option.map (fun oa ->
             match oa with
-            | Value.Ontology oa  -> oa.GetName
+            | Value.Ontology oa  -> oa.NameText
             | Value.Float f -> string f
             | Value.Int i   -> string i
             | Value.Name s  -> s
         )
         |> Option.defaultValue ""
 
-    member this.GetValueWithUnit =
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueText\" instead.")>]
+    member this.GetValue = this.ValueText
+
+    member this.ValueWithUnitText =
         let unit = 
-            this.Unit |> Option.map (fun oa -> oa.GetName)
-        let v = this.GetValue
+            this.Unit |> Option.map (fun oa -> oa.NameText)
+        let v = this.ValueText
         match unit with
         | Some u    -> sprintf "%s %s" v u
         | None      -> v
 
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueWithUnitText\" instead.")>]
+    member this.GetValueWithUnit = this.ValueWithUnitText
+
+    member this.NameText =
+        this.Category
+        |> Option.map (fun factor -> factor.NameText)
+        |> Option.defaultValue ""
+
     /// Returns the name of the category as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.Category
         |> Option.map (fun factor -> factor.GetName)
         |> Option.defaultValue ""
 
     /// Returns the name of the category with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         this.Category
         |> Option.map (fun oa -> oa.GetNameWithNumber)
@@ -191,8 +210,8 @@ type FactorValue =
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            let category = this.Category |> Option.map (fun f -> f.GetName)
-            let unit = this.Unit |> Option.map (fun oa -> oa.GetName)
+            let category = this.Category |> Option.map (fun f -> f.NameText)
+            let unit = this.Unit |> Option.map (fun oa -> oa.NameText)
             let value = 
                 this.Value
                 |> Option.map (fun v ->

--- a/src/ISADotnet/DataModel/Material.fs
+++ b/src/ISADotnet/DataModel/Material.fs
@@ -29,6 +29,7 @@ type MaterialAttribute =
         MaterialAttribute.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
 
     /// Create a ISAJson MaterialAttribute from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumber (term:string) (source:string) (accession:string) =
         let oa = OntologyAnnotation.fromStringWithNumber term source accession
         MaterialAttribute.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
@@ -39,6 +40,7 @@ type MaterialAttribute =
         MaterialAttribute.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
 
     /// Create a ISAJson MaterialAttribute from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumberAndComments (term:string) (source:string) (accession:string) (comments : Comment list) =
         let oa = OntologyAnnotation.fromStringWithNumberAndComments term source accession comments
         MaterialAttribute.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
@@ -48,42 +50,51 @@ type MaterialAttribute =
         ma.CharacteristicType |> Option.map OntologyAnnotation.toString |> Option.defaultValue ("","","")    
 
     /// Returns the name of the characteristic as string
-    [<System.Obsolete("This function is deprecated. Use the member \"GetName\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.NameAsString =
         this.CharacteristicType
         |> Option.map (fun oa -> oa.NameAsString)
         |> Option.defaultValue ""
 
     /// Returns the name of the characteristic with the number as string (e.g. "temperature #2")
-    [<System.Obsolete("This function is deprecated. Use the member \"GetNameWithNumber\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.NameAsStringWithNumber =       
         this.CharacteristicType
         |> Option.map (fun oa -> oa.NameAsStringWithNumber)
         |> Option.defaultValue ""
 
     /// Returns the name of the characteristic as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.CharacteristicType
         |> Option.map (fun oa -> oa.GetName)
         |> Option.defaultValue ""
 
     /// Returns number of Material attribute
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.Number =       
         this.CharacteristicType
         |> Option.bind (fun oa -> oa.Number)
         |> Option.defaultValue ""
 
     /// Returns the name of the characteristic with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         this.CharacteristicType
         |> Option.map (fun oa -> oa.GetNameWithNumber)
+        |> Option.defaultValue ""
+
+    /// Returns the name of the characteristic as string
+    member this.NameText =
+        this.CharacteristicType
+        |> Option.map (fun oa -> oa.NameText)
         |> Option.defaultValue ""
 
     interface IISAPrintable with
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            "OA " + this.GetNameWithNumber
+            "OA " + this.NameText
 
 type MaterialAttributeValue = 
     {
@@ -114,42 +125,50 @@ type MaterialAttributeValue =
         MaterialAttributeValue.create()
 
     /// Returns the name of the category as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.Category
         |> Option.map (fun oa -> oa.GetName)
         |> Option.defaultValue ""
 
     /// Returns the name of the category with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         this.Category
         |> Option.map (fun oa -> oa.GetNameWithNumber)
         |> Option.defaultValue ""
 
-    member this.GetValue =
+    member this.ValueText =
         this.Value
         |> Option.map (fun oa ->
             match oa with
-            | Value.Ontology oa  -> oa.GetName
+            | Value.Ontology oa  -> oa.NameText
             | Value.Float f -> string f
             | Value.Int i   -> string i
             | Value.Name s  -> s
         )
         |> Option.defaultValue ""
 
-    member this.GetValueWithUnit =
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueText\" instead.")>]
+    member this.GetValue = this.ValueText
+
+    member this.ValueWithUnitText =
         let unit = 
-            this.Unit |> Option.map (fun oa -> oa.GetName)
-        let v = this.GetValue
+            this.Unit |> Option.map (fun oa -> oa.NameText)
+        let v = this.ValueText
         match unit with
         | Some u    -> sprintf "%s %s" v u
         | None      -> v
+
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueWithUnitText\" instead.")>]
+    member this.GetValueWithUnit = this.ValueWithUnitText
 
     interface IISAPrintable with
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            let category = this.Category |> Option.map (fun f -> f.GetName)
-            let unit = this.Unit |> Option.map (fun oa -> oa.GetName)
+            let category = this.Category |> Option.map (fun f -> f.NameText)
+            let unit = this.Unit |> Option.map (fun oa -> oa.NameText)
             let value = 
                 this.Value
                 |> Option.map (fun v ->
@@ -209,12 +228,17 @@ type Material =
     static member empty =
         Material.create()
 
-    [<System.Obsolete("This function is deprecated. Use the member \"GetNameWithNumber\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.NameAsString =
         this.Name
         |> Option.defaultValue ""
-
+        
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
+        this.Name
+        |> Option.defaultValue ""
+
+    member this.NameText =
         this.Name
         |> Option.defaultValue ""
 
@@ -225,5 +249,5 @@ type Material =
             let chars = this.Characteristics |> Option.defaultValue [] |> List.length
             match this.MaterialType with
             | Some t ->
-                sprintf "%s [%s; %i characteristics]" this.GetName t.AsString chars
-            | None -> sprintf "%s [%i characteristics]" this.GetName chars
+                sprintf "%s [%s; %i characteristics]" this.NameText t.AsString chars
+            | None -> sprintf "%s [%i characteristics]" this.NameText chars

--- a/src/ISADotnet/DataModel/Ontology.fs
+++ b/src/ISADotnet/DataModel/Ontology.fs
@@ -76,7 +76,7 @@ type OntologyAnnotation =
         | None -> name
 
     /// Returns the name of the ontology as string
-    member this.GetName =
+    member this.NameText =
         this.Name
         |> Option.map (fun av ->
             match av with
@@ -86,11 +86,17 @@ type OntologyAnnotation =
         )
         |> Option.defaultValue ""
 
+    /// Returns the name of the ontology as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
+    member this.GetName = this.NameText
+
     /// Returns number of Ontology annotation
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.Number =       
         this.Comments |> Option.bind (List.tryPick (fun c -> if c.Name = Some "Number" then c.Value else None))       
 
     /// Returns the name of the ontology with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         let name = this.GetName
         match this.Number with
@@ -126,6 +132,7 @@ type OntologyAnnotation =
             (Option.fromValueWithDefault [] comments)
 
     /// Create a ISAJson Ontology Annotation value from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumber (term:string) (source:string) (accession:string) =
         let t,number = 
             let lastIndex = term.LastIndexOf '#'
@@ -134,12 +141,13 @@ type OntologyAnnotation =
         OntologyAnnotation.fromStringWithComments t source accession (numberComment |> Option.defaultValue [])      
 
     /// Create a ISAJson Ontology Annotation value from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumberAndComments (term:string) (source:string) (accession:string) (comments : Comment list) =
         let t,number = 
             let lastIndex = term.LastIndexOf '#'
             term.Remove(lastIndex).Trim(), term.Substring(lastIndex+1).Trim()
         let numberComment = Option.fromValueWithDefault "" number |> Option.map ((fun n -> Comment.create(Name = "Number", Value = n)) >> List.singleton)
-        OntologyAnnotation.fromStringWithComments t source accession ((numberComment |> Option.defaultValue []) @ comments)   
+        OntologyAnnotation.fromStringWithComments term source accession ((numberComment |> Option.defaultValue []) @ comments)   
 
     /// Get a ISATab string entries from an ISAJson Ontology Annotation object (name,source,accession)
     static member toString (oa : OntologyAnnotation) =
@@ -152,7 +160,7 @@ type OntologyAnnotation =
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            "OA " + this.GetNameWithNumber
+            "OA " + this.NameText
 
 
 type OntologySourceReference =

--- a/src/ISADotnet/DataModel/Process.fs
+++ b/src/ISADotnet/DataModel/Process.fs
@@ -25,19 +25,29 @@ type ProcessParameterValue =
     static member empty =
         ProcessParameterValue.create()
 
+
     /// Returns the name of the category as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.Category
         |> Option.map (fun oa -> oa.GetName)
         |> Option.defaultValue ""
 
     /// Returns the name of the category with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         this.Category
         |> Option.map (fun oa -> oa.GetNameWithNumber)
         |> Option.defaultValue ""
 
-    member this.GetValue =
+    /// Returns the name of the category as string
+    member this.NameText =
+        this.Category
+        |> Option.map (fun oa -> oa.NameText)
+        |> Option.defaultValue ""
+
+    member this.ValueText =
+    
         this.Value
         |> Option.map (fun oa ->
             match oa with
@@ -48,20 +58,26 @@ type ProcessParameterValue =
         )
         |> Option.defaultValue ""
 
-    member this.GetValueWithUnit =
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueText\" instead.")>]
+    member this.GetValue = this.ValueText
+
+    member this.ValueWithUnitText =
         let unit = 
-            this.Unit |> Option.map (fun oa -> oa.GetName)
-        let v = this.GetValue
+            this.Unit |> Option.map (fun oa -> oa.NameText)
+        let v = this.ValueText
         match unit with
         | Some u    -> sprintf "%s %s" v u
         | None      -> v
+
+    [<System.Obsolete("This function is deprecated. Use the member \"ValueWithUnitText\" instead.")>]
+    member this.GetValueWithUnit = this.ValueWithUnitText
 
     interface IISAPrintable with
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            let category = this.Category |> Option.map (fun f -> f.GetName)
-            let unit = this.Unit |> Option.map (fun oa -> oa.GetName)
+            let category = this.Category |> Option.map (fun f -> f.NameText)
+            let unit = this.Unit |> Option.map (fun oa -> oa.NameText)
             let value = 
                 this.Value
                 |> Option.map (fun v ->

--- a/src/ISADotnet/DataModel/Protocol.fs
+++ b/src/ISADotnet/DataModel/Protocol.fs
@@ -35,11 +35,13 @@ type ProtocolParameter =
         ProtocolParameter.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
 
     /// Create a ISAJson Protocol Parameter from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumber (term:string) (source:string) (accession:string) =
         let oa = OntologyAnnotation.fromStringWithNumber term source accession
         ProtocolParameter.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
 
     /// Create a ISAJson Protocol Parameter from string entries, where the term name can contain a # separated number. e.g: "temperature unit #2"
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     static member fromStringWithNumberAndComments (term:string) (source:string) (accession:string) (comments : Comment list) =
         let oa = OntologyAnnotation.fromStringWithNumberAndComments term source accession comments
         ProtocolParameter.make None (Option.fromValueWithDefault OntologyAnnotation.empty oa)
@@ -49,26 +51,34 @@ type ProtocolParameter =
         pp.ParameterName |> Option.map OntologyAnnotation.toString |> Option.defaultValue ("","","")        
 
     /// Returns the name of the parameter as string
-    [<System.Obsolete("This function is deprecated. Use the member \"GetName\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.NameAsString =
         this.ParameterName
         |> Option.map (fun oa -> oa.GetName)
         |> Option.defaultValue ""
 
     /// Returns the name of the parameter with the number as string (e.g. "temperature #2")
-    [<System.Obsolete("This function is deprecated. Use the member \"GetNameWithNumber\" instead.")>]
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.NameAsStringWithNumber =       
         this.ParameterName
         |> Option.map (fun oa -> oa.GetNameWithNumber)
         |> Option.defaultValue ""
 
     /// Returns the name of the parameter as string
+    [<System.Obsolete("This function is deprecated. Use the member \"NameText\" instead.")>]
     member this.GetName =
         this.ParameterName
         |> Option.map (fun oa -> oa.GetName)
         |> Option.defaultValue ""
 
+    /// Returns the name of the parameter as string
+    member this.NameText =
+        this.ParameterName
+        |> Option.map (fun oa -> oa.NameText)
+        |> Option.defaultValue ""
+
     /// Returns the name of the parameter with the number as string (e.g. "temperature #2")
+    [<System.Obsolete("This function is deprecated. Numbering support will soon be dropped")>]
     member this.GetNameWithNumber =       
         this.ParameterName
         |> Option.map (fun oa -> oa.GetNameWithNumber)
@@ -78,7 +88,7 @@ type ProtocolParameter =
         member this.Print() =
             this.ToString()
         member this.PrintCompact() =
-            "OA " + this.GetNameWithNumber
+            "OA " + this.NameText
 
 type Component = 
     {

--- a/tests/ISADotNet.Tests/ISADotNet.Tests.fsproj
+++ b/tests/ISADotNet.Tests/ISADotNet.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="ISADotnet\APITests.fs" />
     <Compile Include="ISADotNet.XLSX\InvestigationFileTests.fs" />
     <Compile Include="ISADotNet.XLSX\AssayFileTests.fs" />
+    <Compile Include="ISADotNet.XLSX\RegexPattern.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/tests/ISADotNet.Tests/ISADotNet.XLSX/AssayFileTests.fs
+++ b/tests/ISADotNet.Tests/ISADotNet.XLSX/AssayFileTests.fs
@@ -52,11 +52,31 @@ let testColumnHeaderFunctions =
             let header = AnnotationColumn.ColumnHeader.fromStringHeader headerString
 
             let testComment = Comment.fromString "Number" "5"
-            let testOntology = OntologyAnnotation.make None (Some (AnnotationValue.Text "Name")) None None (Some [testComment])
+            let testOntology = OntologyAnnotation.make None (Some (AnnotationValue.Text "Name#5")) None None (Some [testComment])
 
             let testHeader = AnnotationColumn.ColumnHeader.create headerString "NamedHeader" (Some testOntology) (Some 5)
 
             Expect.equal header testHeader "Did not parse Name correctly"
+        )
+        testCase "NameWithBrackets" (fun () ->
+        
+            let headerString = "NamedHeader [Name [Stuff]]"
+        
+            let header = AnnotationColumn.ColumnHeader.fromStringHeader headerString
+            
+            let testHeader = AnnotationColumn.ColumnHeader.create headerString "NamedHeader" (OntologyAnnotation.fromString "Name [Stuff]" "" "" |> Some) None
+            
+            Expect.equal header testHeader "Dit not parse Name correctly"
+        )
+        testCase "NameWithHashtag" (fun () ->
+            
+            let headerString = "NamedHeader [Name#Stuff]"
+            
+            let header = AnnotationColumn.ColumnHeader.fromStringHeader headerString
+                
+            let testHeader = AnnotationColumn.ColumnHeader.create headerString "NamedHeader" (OntologyAnnotation.fromString "Name#Stuff" "" "" |> Some) None
+                
+            Expect.equal header testHeader "Dit not parse Name correctly"
         )
         testCase "AccessionWithNumber" (fun () ->
 
@@ -638,10 +658,7 @@ let testAssayFileReader =
 
     let time1 = ProtocolParameter.fromStringWithValueOrder "time unit" "UO" "http://purl.obolibrary.org/obo/UO_0000003" 3
 
-    //let time2Comment = Comment.fromString "Number" "2"  
-    //let time2Ontology = OntologyAnnotation.make None (Some (AnnotationValue.Text "time unit")) (Some "UO") (Some "http://purl.obolibrary.org/obo/UO_0000003") (Some [time2Comment])
-    let time2 = Factor.fromStringWithNumberValueOrder "time unit" "time unit#2" "UO" "http://purl.obolibrary.org/obo/UO_0000003" 4
-
+    let time2 = Factor.fromStringWithNumberValueOrder "time unit#2" "time unit#2" "UO" "http://purl.obolibrary.org/obo/UO_0000003" 4
 
     let leafSize = MaterialAttribute.fromStringWithValueOrder "leaf size" "TO" "http://purl.obolibrary.org/obo/TO_0002637" 0
 

--- a/tests/ISADotNet.Tests/ISADotNet.XLSX/RegexPattern.fs
+++ b/tests/ISADotNet.Tests/ISADotNet.XLSX/RegexPattern.fs
@@ -1,0 +1,242 @@
+﻿module RegexPatternTests
+
+open Expecto
+open TestingUtils
+
+open ISADotNet.XLSX.AssayFile.AnnotationColumn.RegexPattern
+open System.Text.RegularExpressions
+
+//let kindPattern = @"[^\[(]*(?= [\[\(])"
+//let namePattern = @"(?<= \[).*(?=[\]])"
+//let ontologySourcePattern = @"(?<=\()\S+:[^;)#]*(?=[\)\#])"
+//let numberPattern = @"(?<=#)\d+(?=[\)\]])"
+
+/// Patterns found at ISADotNet.XLSX.AssayFile, AnnotationColumn.RegexPattern
+
+//(?<=\()
+//(?=[\)\#])
+
+module TestCases =
+    [<Literal>]
+    let case1 = "Source Name"
+    [<Literal>]
+    let case2 = "Sample Name"
+    [<Literal>]
+    let case3 = "Characteristics [Sample type]"
+    [<Literal>]
+    let case5 = "Factor [Sample type#2]"
+    [<Literal>]
+    let case6 = "Parameter [biological replicate#2]"
+    [<Literal>]
+    let case7 = "Data File Name"
+    [<Literal>]
+    let case8 = "Term Source REF (NFDI4PSO:0000064)"
+    [<Literal>]
+    let case9 = "Term Source REF (NFDI4PSO:0000064#2)"
+    [<Literal>]
+    let case10 = "Term Accession Number (MS:1001809)"
+    [<Literal>]
+    let case11 = "Term Accession Number (MS:1001809#2)"
+    [<Literal>]
+    let case12 = "Unit"
+    [<Literal>]
+    let case13 = "Unit (#3)"
+    [<Literal>]
+    let case14 = "Term Accession Number ()" 
+    [<Literal>]
+    let case15 = "Parameter [hello world]"
+    [<Literal>]
+    let case16 = "Parameter [hello (world)]"
+    [<Literal>]
+    let case17 = "Parameter [hello[world]]"
+    [<Literal>]
+    let case18 = "Parameter [hello ]]"
+    [<Literal>]
+    let case19 = "http://purl.obolibrary.org/obo/NFDI4PSO_0000064"
+    [<Literal>]
+    let case20 = "Term Accession Number (#2)"
+
+[<Tests>]
+let testRegexPatternMatching = 
+    testList "Regex pattern tests" [
+        test "kindPattern 'Source Name'" {
+            let regExMatch = Regex.Match(TestCases.case1, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Source Name" ""
+        }
+
+        test "kindPattern 'Characteristic [Sample type]'" {
+            let regExMatch = Regex.Match(TestCases.case3, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Characteristics" ""
+        }
+
+        test "kindPattern 'Term Source REF (NFDI4PSO:0000064)'" {
+            let regExMatch = Regex.Match(TestCases.case8, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Term Source REF" ""
+        }
+
+        test "kindPattern 'Term Accession Number (MS:1001809#2)'" {
+            let regExMatch = Regex.Match(TestCases.case11, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Term Accession Number" ""
+        }
+
+        test "kindPattern 'Unit (#3)'" {
+            let regExMatch = Regex.Match(TestCases.case13, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Unit" ""
+        }
+
+        test "kindPattern 'Term Accession Number ()'" {
+            let regExMatch = Regex.Match(TestCases.case14, columnTypePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Term Accession Number" ""
+        }
+
+        test "namePattern 'Source Name'" {
+            let regExMatch = Regex.Match(TestCases.case1, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "namePattern 'Characteristic [Sample type]'" {
+            let regExMatch = Regex.Match(TestCases.case3, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "Sample type" ""
+        }
+
+        test "namePattern 'Term Source REF (NFDI4PSO:0000064)'" {
+            let regExMatch = Regex.Match(TestCases.case8, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "namePattern 'Term Accession Number (MS:1001809#2)'" {
+            let regExMatch = Regex.Match(TestCases.case11, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "namePattern 'Unit (#3)'" {
+            let regExMatch = Regex.Match(TestCases.case13, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "namePattern 'Term Accession Number ()'" {
+            let regExMatch = Regex.Match(TestCases.case14, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "namePattern 'Parameter [hello world]'" {
+            let regExMatch = Regex.Match(TestCases.case15, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "hello world" ""
+        }
+
+        test "namePattern 'Parameter [hello (world)]'" {
+            let regExMatch = Regex.Match(TestCases.case16, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "hello (world)" ""
+        }
+
+        test "namePattern 'Parameter [hello[world]]'" {
+            let regExMatch = Regex.Match(TestCases.case17, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "hello[world]" ""
+        }
+
+        test "namePattern 'Parameter [hello ]]'" {
+            let regExMatch = Regex.Match(TestCases.case18, namePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "hello ]" ""
+        }
+
+        test "ontologySourcePattern 'Source Name'" {
+            let regExMatch = Regex.Match(TestCases.case1, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "ontologySourcePattern 'Characteristic [Sample type]'" {
+            let regExMatch = Regex.Match(TestCases.case3, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "ontologySourcePattern 'Term Source REF (NFDI4PSO:0000064)'" {
+            let regExMatch = Regex.Match(TestCases.case8, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "NFDI4PSO:0000064" ""
+        }
+
+        test "ontologySourcePattern 'Term Accession Number (MS:1001809#2)'" {
+            let regExMatch = Regex.Match(TestCases.case11, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "MS:1001809" ""
+        }
+
+        test "ontologySourcePattern 'Unit (#3)'" {
+            let regExMatch = Regex.Match(TestCases.case13, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "ontologySourcePattern 'Term Accession Number ()'" {
+            let regExMatch = Regex.Match(TestCases.case14, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "ontologySourcePattern get from purl url." {
+            let regExMatch = Regex.Match(TestCases.case19, ontologySourcePattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "NFDI4PSO_0000064" ""
+        }
+
+        test "numberPattern 'Source Name'" {
+            let regExMatch = Regex.Match(TestCases.case1, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "numberPattern 'Characteristic [Sample type]'" {
+            let regExMatch = Regex.Match(TestCases.case3, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "numberPattern 'Term Source REF (NFDI4PSO:0000064)'" {
+            let regExMatch = Regex.Match(TestCases.case8, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "numberPattern 'Term Accession Number (MS:1001809#2)'" {
+            let regExMatch = Regex.Match(TestCases.case11, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "2" ""
+        }
+
+        test "numberPattern 'Unit (#3)'" {
+            let regExMatch = Regex.Match(TestCases.case13, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "3" ""
+        }
+
+        test "numberPattern 'Term Accession Number ()'" {
+            let regExMatch = Regex.Match(TestCases.case14, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "" ""
+        }
+
+        test "numberPattern 'Term Accession Number (#2)'" {
+            let regExMatch = Regex.Match(TestCases.case20, numberPattern)
+            let regexValue = regExMatch.Value.Trim()
+            Expect.equal regexValue "2" ""
+        }
+
+    ]

--- a/tests/ISADotNet.Tests/Main.fs
+++ b/tests/ISADotNet.Tests/Main.fs
@@ -5,6 +5,9 @@ open Expecto
 [<EntryPoint>]
 let main argv =
 
+    //Regex Test
+    Tests.runTestsWithCLIArgs [Tests.CLIArguments.Sequenced] argv RegexPatternTests.testRegexPatternMatching |> ignore
+
     //XLSX IO Test
     Tests.runTestsWithCLIArgs [Tests.CLIArguments.Sequenced] argv ISAXLSXInvestigationTests.testStringConversions |> ignore
     Tests.runTestsWithCLIArgs [Tests.CLIArguments.Sequenced] argv ISAXLSXInvestigationTests.testSparseTable |> ignore


### PR DESCRIPTION
### Assay File Header parsing

Removed some failing cases of header parsing (e.g. when there were brackets inside the name). Examples for these new rules are seen below:

![image](https://user-images.githubusercontent.com/17880410/161771782-18e99651-08f0-4c35-9840-204cfc8dea0a.png)

`#` are now also included in the name together with potential numberings. Explanation see next section.

### Dropping number handling

`ISADotNet` should follow more closely the `ISATab` specification and not impose any unncessary additional assumptions when simply parsing assay files. Therefore from now on ISADotNet will move towards interpreting headers with `Swate` style numbering (e.g. `Parameter [temperature unit#2]`) oblivious to these numberings. 

Members incoporating these numbering rules (e.g. `Factor.GetNameAsStringWithNumber`) are now marked as `deprecated` and will be omitted in future releases.

### XLSX File IO verbosity
Failing xlsx readers will now be more verbose about why they are failing

### Small fixes

- dag vizualization now makes edges distinct per source target pair
- include empty study by default when writing investigation file
- fix assay reading no processes as Some empty lists
- fix outputByCharacteristic getter function


-----------------
Header parsing and number handling changes might be of interest to you:
@omaus, @Freymaurer, @Joott, @muehlhaus 

----------------

fixes #50
fixes #52
fixes #54 
fixes #56