### PR TITLE
Small fix to investigation json parser

### DIFF
--- a/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
+++ b/src/ISADotNet.XLSX/InvestigationFile/Investigation.fs
@@ -156,19 +156,21 @@ module Investigation =
    
     let toRows (investigation:Investigation) : seq<SparseRow> =
         let insertRemarks (remarks:Remark list) (rows:seq<SparseRow>) = 
-            let rm = remarks |> List.map Remark.toTuple |> Map.ofList 
-            let rec loop i l nl =
-                match Map.tryFind i rm with
-                | Some remark ->
-                     SparseRow.fromValues [wrapRemark remark] :: nl
-                    |> loop (i+1) l
-                | None -> 
-                    match l with
-                    | [] -> nl
-                    | h :: t -> 
-                        loop (i+1) t (h::nl)
-            loop 1 (rows |> List.ofSeq) []
-            |> List.rev
+            try 
+                let rm = remarks |> List.map Remark.toTuple |> Map.ofList            
+                let rec loop i l nl =
+                    match Map.tryFind i rm with
+                    | Some remark ->
+                         SparseRow.fromValues [wrapRemark remark] :: nl
+                        |> loop (i+1) l
+                    | None -> 
+                        match l with
+                        | [] -> nl
+                        | h :: t -> 
+                            loop (i+1) t (h::nl)
+                loop 1 (rows |> List.ofSeq) []
+                |> List.rev
+            with | _ -> rows |> Seq.toList
         seq {
             yield  SparseRow.fromValues[ontologySourceReferenceLabel]
             yield! OntologySourceReference.toRows (Option.defaultValue [] investigation.OntologySourceReferences)

--- a/src/ISADotNet/JsonIO/Investigation.fs
+++ b/src/ISADotNet/JsonIO/Investigation.fs
@@ -8,6 +8,10 @@ module Investigation =
     
     let fromString (s:string) = 
         JsonSerializer.Deserialize<Investigation>(s,JsonExtensions.options)
+        |> fun i -> 
+            if isNull (box i.Remarks) then
+                {i with Remarks = []}
+            else i
 
     let toString (i:Investigation) = 
         JsonSerializer.Serialize<Investigation>(i,JsonExtensions.options)
@@ -15,6 +19,7 @@ module Investigation =
     let fromFile (path : string) = 
         File.ReadAllText path 
         |> fromString
+        
 
     let toFile (path : string) (i:Investigation) = 
         File.WriteAllText(path,toString i)

--- a/tests/ISADotNet.Tests/ISADotnet/ISAJsonTests.fs
+++ b/tests/ISADotNet.Tests/ISADotnet/ISAJsonTests.fs
@@ -270,6 +270,17 @@ let testInvestigationFile =
             Expect.sequenceEqual o i "Written investigation file does not match read investigation file"
         )
         |> testSequenced
+
+        testCase "HandleEmptyRemarks" (fun () ->
+
+            let json = "{}"
+            
+            let i = Investigation.fromString json
+
+            Expect.equal i.Remarks List.empty "Remark list should be an empty list."
+        )
+        |> testSequenced
+
         testCase "FullInvestigation" (fun () ->
                   
             let comment = 


### PR DESCRIPTION
Until now, when an isa investigation json string was read by the json parser, `null` was set as the value for the `Remarks` field. This would lead to errors when trying to parse this object to an xlsx afterwards. 
Now fixed and a test was added.