### PR TITLE
Linq querying writeback

### DIFF
--- a/ISADotNet.sln
+++ b/ISADotNet.sln
@@ -36,7 +36,9 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ISADotNet.Viz", "src\ISADot
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ISADotNet.QueryModel", "src\ISADotNet.QueryModel\ISADotNet.QueryModel.fsproj", "{10E8D0C4-B603-41A1-BC4D-68B672188F28}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ISADotNet.Validation", "src\ISADotNet.Validation\ISADotNet.Validation.fsproj", "{AC745163-53B6-4062-A3F9-9DC7FFE484CE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ISADotNet.Validation", "src\ISADotNet.Validation\ISADotNet.Validation.fsproj", "{AC745163-53B6-4062-A3F9-9DC7FFE484CE}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Build", "build\Build.fsproj", "{FD9BB9F2-D4D7-4045-9AF7-5498B602E28E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +70,10 @@ Global
 		{AC745163-53B6-4062-A3F9-9DC7FFE484CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC745163-53B6-4062-A3F9-9DC7FFE484CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC745163-53B6-4062-A3F9-9DC7FFE484CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD9BB9F2-D4D7-4045-9AF7-5498B602E28E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD9BB9F2-D4D7-4045-9AF7-5498B602E28E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD9BB9F2-D4D7-4045-9AF7-5498B602E28E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD9BB9F2-D4D7-4045-9AF7-5498B602E28E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,3 @@
-dotnet tool restore
-dotnet fake build %*
+@echo off
+cls 
+dotnet run --project ./build/build.fsproj %*

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,4 @@
 set -eu
 set -o pipefail
 
-dotnet tool restore
-dotnet fake build "$@"
+dotnet run --project ./build/Build.fsproj "$@"

--- a/build/BasicTasks.fs
+++ b/build/BasicTasks.fs
@@ -1,0 +1,30 @@
+﻿module BasicTasks
+
+open BlackFox.Fake
+open Fake.IO
+open Fake.DotNet
+open Fake.IO.Globbing.Operators
+
+open ProjectInfo
+
+let setPrereleaseTag = BuildTask.create "SetPrereleaseTag" [] {
+    printfn "Please enter pre-release package suffix"
+    let suffix = System.Console.ReadLine()
+    prereleaseSuffix <- suffix
+    prereleaseTag <- (sprintf "%i.%i.%i-%s" release.SemVer.Major release.SemVer.Minor release.SemVer.Patch suffix)
+    isPrerelease <- true
+}
+
+let clean = BuildTask.create "Clean" [] {
+    !! "src/**/bin"
+    ++ "src/**/obj"
+    ++ "tests/**/bin"
+    ++ "tests/**/obj"
+    ++ "pkg"
+    |> Shell.cleanDirs 
+}
+
+let build = BuildTask.create "Build" [clean] {
+    solutionFile
+    |> DotNet.build id
+}

--- a/build/Build.fs
+++ b/build/Build.fs
@@ -1,0 +1,49 @@
+﻿module Build
+open BlackFox.Fake
+open System.IO
+open Fake.Core
+open Fake.DotNet
+open Fake.IO
+open Fake.IO.FileSystemOperators
+open Fake.IO.Globbing.Operators
+open Fake.Tools
+
+open Helpers
+
+initializeContext()
+
+open BasicTasks
+open TestTasks
+open PackageTasks
+open DocumentationTasks
+open ReleaseTasks
+
+/// Full release of nuget package, git tag, and documentation for the stable version.
+let _release = 
+    BuildTask.createEmpty 
+        "Release" 
+        [clean; build; runTests; pack; buildDocs; createTag; publishNuget; releaseDocs]
+
+/// Full release of nuget package, git tag, and documentation for the prerelease version.
+let _preRelease = 
+    BuildTask.createEmpty 
+        "PreRelease" 
+        [setPrereleaseTag; clean; build; runTests; packPrerelease; buildDocsPrerelease; createPrereleaseTag; publishNugetPrerelease; prereleaseDocs]
+
+/// Full release of nuget package for the prerelease version.
+let _releaseNoDocs = 
+    BuildTask.createEmpty 
+        "ReleaseNoDocs" 
+        [clean; build; runTests; pack; createTag; publishNuget;]
+
+/// Full release of nuget package for the prerelease version.
+let _preReleaseNoDocs = 
+    BuildTask.createEmpty 
+        "PreReleaseNoDocs" 
+        [setPrereleaseTag; clean; build; runTests; packPrerelease; createPrereleaseTag; publishNugetPrerelease]
+
+ReleaseNotesTasks.updateReleaseNotes |> ignore
+
+[<EntryPoint>]
+let main args = 
+    runOrDefault build args

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Helpers.fs" />
+    <Compile Include="MessagePrompts.fs" />
+    <Compile Include="ProjectInfo.fs" />
+    <Compile Include="ReleaseNotesTasks.fs" />
+    <Compile Include="BasicTasks.fs" />
+    <Compile Include="TestTasks.fs" />
+    <Compile Include="PackageTasks.fs" />
+    <Compile Include="DocumentationTasks.fs" />
+    <Compile Include="ReleaseTasks.fs" />
+    <Compile Include="Build.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BlackFox.Fake.BuildTask" Version="0.1.3" />
+    <PackageReference Include="Fake.Api.Github" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.Core.Process" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.Core.ReleaseNotes" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.Core.Target" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.DotNet.Cli" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.DotNet.MSBuild" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.IO.FileSystem" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.Tools.Git" Version="5.23.0-alpha002" />
+	<PackageReference Include="Fake.Extensions.Release" Version="0.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/build/DocumentationTasks.fs
+++ b/build/DocumentationTasks.fs
@@ -1,0 +1,35 @@
+﻿module DocumentationTasks
+
+open Helpers
+open ProjectInfo
+open BasicTasks
+
+open BlackFox.Fake
+
+let buildDocs = BuildTask.create "BuildDocs" [build] {
+    printfn "building docs with stable version %s" stableVersionTag
+    runDotNet 
+        (sprintf "fsdocs build --eval --clean --properties Configuration=Release --parameters fsdocs-package-version %s" stableVersionTag)
+        "./"
+}
+
+let buildDocsPrerelease = BuildTask.create "BuildDocsPrerelease" [setPrereleaseTag; build] {
+    printfn "building docs with prerelease version %s" prereleaseTag
+    runDotNet 
+        (sprintf "fsdocs build --eval --clean --properties Configuration=Release --parameters fsdocs-package-version %s" prereleaseTag)
+        "./"
+}
+
+let watchDocs = BuildTask.create "WatchDocs" [build] {
+    printfn "watching docs with stable version %s" stableVersionTag
+    runDotNet 
+        (sprintf "fsdocs watch --eval --clean --properties Configuration=Release --parameters fsdocs-package-version %s" stableVersionTag)
+        "./"
+}
+
+let watchDocsPrerelease = BuildTask.create "WatchDocsPrerelease" [setPrereleaseTag; build] {
+    printfn "watching docs with prerelease version %s" prereleaseTag
+    runDotNet 
+        (sprintf "fsdocs watch --eval --clean --properties Configuration=Release --parameters fsdocs-package-version %s" prereleaseTag)
+        "./"
+}

--- a/build/Helpers.fs
+++ b/build/Helpers.fs
@@ -1,0 +1,28 @@
+﻿module Helpers
+
+open BlackFox.Fake
+open Fake.Core
+open Fake.DotNet
+
+let initializeContext () =
+    let execContext = Context.FakeExecutionContext.Create false "build.fsx" [ ]
+    Context.setExecutionContext (Context.RuntimeContext.Fake execContext)
+
+/// Executes a dotnet command in the given working directory
+let runDotNet cmd workingDir =
+    let result =
+        DotNet.exec (DotNet.Options.withWorkingDirectory workingDir) cmd ""
+    if result.ExitCode <> 0 then failwithf "'dotnet %s' failed in %s" cmd workingDir
+
+let runOrDefault defaultTarget args =
+    Trace.trace (sprintf "%A" args)
+    try
+        match args with
+        | [| target |] -> Target.runOrDefault target
+        | arr when args.Length > 1 ->
+            Target.run 0 (Array.head arr) ( Array.tail arr |> List.ofArray )
+        | _ -> BuildTask.runOrDefault defaultTarget
+        0
+    with e ->
+        printfn "%A" e
+        1

--- a/build/MessagePrompts.fs
+++ b/build/MessagePrompts.fs
@@ -1,0 +1,18 @@
+﻿module MessagePrompts
+
+let prompt (msg:string) =
+    System.Console.Write(msg)
+    System.Console.ReadLine().Trim()
+    |> function | "" -> None | s -> Some s
+    |> Option.map (fun s -> s.Replace ("\"","\\\""))
+
+let rec promptYesNo msg =
+    match prompt (sprintf "%s [Yn]: " msg) with
+    | Some "Y" | Some "y" -> true
+    | Some "N" | Some "n" -> false
+    | _ -> System.Console.WriteLine("Sorry, invalid answer"); promptYesNo msg
+
+let releaseMsg = """This will stage all uncommitted changes, push them to the origin and bump the release version to the latest number in the RELEASE_NOTES.md file. 
+    Do you want to continue?"""
+
+let releaseDocsMsg = """This will push the docs to gh-pages. Remember building the docs prior to this. Do you want to continue?"""

--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -1,0 +1,64 @@
+﻿module PackageTasks
+
+open ProjectInfo
+
+open MessagePrompts
+open BasicTasks
+open TestTasks
+
+open BlackFox.Fake
+open Fake.Core
+open Fake.IO.Globbing.Operators
+
+open System.Text.RegularExpressions
+
+/// https://github.com/Freymaurer/Fake.Extensions.Release#release-notes-in-nuget
+let private replaceCommitLink input = 
+    let commitLinkPattern = @"\[\[#[a-z0-9]*\]\(.*\)\] "
+    Regex.Replace(input,commitLinkPattern,"")
+
+let pack = BuildTask.create "Pack" [clean; build; runTests] {
+    if promptYesNo (sprintf "creating stable package with version %s OK?" stableVersionTag ) 
+        then
+            !! "src/**/*.*proj"
+            -- "src/bin/*"
+            |> Seq.iter (Fake.DotNet.DotNet.pack (fun p ->
+                let msBuildParams =
+                    {p.MSBuildParams with 
+                        Properties = ([
+                            "Version",stableVersionTag
+                            "PackageReleaseNotes",  (release.Notes |> List.map replaceCommitLink |> String.concat "\r\n" )
+                        ] @ p.MSBuildParams.Properties)
+                    }
+                {
+                    p with 
+                        MSBuildParams = msBuildParams
+                        OutputPath = Some pkgDir
+                }
+            ))
+    else failwith "aborted"
+}
+
+let packPrerelease = BuildTask.create "PackPrerelease" [setPrereleaseTag; clean; build; runTests] {
+    if promptYesNo (sprintf "package tag will be %s OK?" prereleaseTag )
+        then 
+            !! "src/**/*.*proj"
+            -- "src/bin/*"
+            |> Seq.iter (Fake.DotNet.DotNet.pack (fun p ->
+                        let msBuildParams =
+                            {p.MSBuildParams with 
+                                Properties = ([
+                                    "Version", prereleaseTag
+                                    "PackageReleaseNotes",  (release.Notes |> List.map replaceCommitLink  |> String.toLines )
+                                ] @ p.MSBuildParams.Properties)
+                            }
+                        {
+                            p with 
+                                VersionSuffix = Some prereleaseSuffix
+                                OutputPath = Some pkgDir
+                                MSBuildParams = msBuildParams
+                        }
+            ))
+    else
+        failwith "aborted"
+}

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -1,0 +1,37 @@
+﻿module ProjectInfo
+
+open Fake.Core
+
+let project = "arcIO.NET"
+
+let testProjects = 
+    [
+        // add relative paths (from project root) to your testprojects here
+    ]
+
+let solutionFile  = $"{project}.sln"
+
+let configuration = "Release"
+
+let gitOwner = "nfdi4plants"
+
+let gitHome = $"https://github.com/{gitOwner}"
+
+let projectRepo = $"https://github.com/{gitOwner}/{project}"
+
+let pkgDir = "pkg"
+
+// Create RELEASE_NOTES.md if not existing. Or "release" would throw an error.
+Fake.Extensions.Release.ReleaseNotes.ensure()
+
+let release = ReleaseNotes.load "RELEASE_NOTES.md"
+
+let stableVersion = SemVer.parse release.NugetVersion
+
+let stableVersionTag = (sprintf "%i.%i.%i" stableVersion.Major stableVersion.Minor stableVersion.Patch )
+
+let mutable prereleaseSuffix = ""
+
+let mutable prereleaseTag = ""
+
+let mutable isPrerelease = false

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -2,7 +2,7 @@
 
 open Fake.Core
 
-let project = "arcIO.NET"
+let project = "ISADotNet"
 
 let testProjects = 
     [

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -6,7 +6,7 @@ let project = "ISADotNet"
 
 let testProjects = 
     [
-        // add relative paths (from project root) to your testprojects here
+        "tests/ISADotNet.Tests/ISADotNet.Tests.fsproj"
     ]
 
 let solutionFile  = $"{project}.sln"

--- a/build/ReleaseNotesTasks.fs
+++ b/build/ReleaseNotesTasks.fs
@@ -1,0 +1,29 @@
+﻿module ReleaseNotesTasks
+
+open Fake.Extensions.Release
+open BlackFox.Fake
+
+/// This might not be necessary, mostly useful for apps which want to display current version as it creates an accessible F# version script from RELEASE_NOTES.md
+let createAssemblyVersion = BuildTask.create "createvfs" [] {
+    AssemblyVersion.create ProjectInfo.project
+}
+
+// https://github.com/Freymaurer/Fake.Extensions.Release#releaseupdate
+let updateReleaseNotes = BuildTask.createFn "ReleaseNotes" [] (fun config ->
+    ReleaseNotes.update(ProjectInfo.gitOwner, ProjectInfo.project, config)
+)
+
+
+// https://github.com/Freymaurer/Fake.Extensions.Release#githubdraft
+let githubDraft = BuildTask.createFn "GithubDraft" [] (fun config ->
+
+    let body = "We are ready to go for the first release!"
+
+    Github.draft(
+        ProjectInfo.gitOwner,
+        ProjectInfo.project,
+        (Some body),
+        None,
+        config
+    )
+)

--- a/build/ReleaseTasks.fs
+++ b/build/ReleaseTasks.fs
@@ -1,0 +1,85 @@
+﻿module ReleaseTasks
+
+open MessagePrompts
+open ProjectInfo
+open BasicTasks
+open TestTasks
+open PackageTasks
+open DocumentationTasks
+
+open BlackFox.Fake
+open Fake.Core
+open Fake.DotNet
+open Fake.Api
+open Fake.Tools
+open Fake.IO
+open Fake.IO.Globbing.Operators
+
+let createTag = BuildTask.create "CreateTag" [clean; build; runTests; pack] {
+    if promptYesNo (sprintf "tagging branch with %s OK?" stableVersionTag ) then
+        Git.Branches.tag "" stableVersionTag
+        Git.Branches.pushTag "" projectRepo stableVersionTag
+    else
+        failwith "aborted"
+}
+
+let createPrereleaseTag = BuildTask.create "CreatePrereleaseTag" [setPrereleaseTag; clean; build; runTests; packPrerelease] {
+    if promptYesNo (sprintf "tagging branch with %s OK?" prereleaseTag ) then 
+        Git.Branches.tag "" prereleaseTag
+        Git.Branches.pushTag "" projectRepo prereleaseTag
+    else
+        failwith "aborted"
+}
+
+
+let publishNuget = BuildTask.create "PublishNuget" [clean; build; runTests; pack] {
+    let targets = (!! (sprintf "%s/*.*pkg" pkgDir ))
+    for target in targets do printfn "%A" target
+    let msg = sprintf "release package with version %s?" stableVersionTag
+    if promptYesNo msg then
+        let source = "https://api.nuget.org/v3/index.json"
+        let apikey =  Environment.environVar "NUGET_KEY"
+        for artifact in targets do
+            let result = DotNet.exec id "nuget" (sprintf "push -s %s -k %s %s --skip-duplicate" source apikey artifact)
+            if not result.OK then failwith "failed to push packages"
+    else failwith "aborted"
+}
+
+let publishNugetPrerelease = BuildTask.create "PublishNugetPrerelease" [clean; build; runTests; packPrerelease] {
+    let targets = (!! (sprintf "%s/*.*pkg" pkgDir ))
+    for target in targets do printfn "%A" target
+    let msg = sprintf "release package with version %s?" prereleaseTag 
+    if promptYesNo msg then
+        let source = "https://api.nuget.org/v3/index.json"
+        let apikey =  Environment.environVar "NUGET_KEY"
+        for artifact in targets do
+            let result = DotNet.exec id "nuget" (sprintf "push -s %s -k %s %s --skip-duplicate" source apikey artifact)
+            if not result.OK then failwith "failed to push packages"
+    else failwith "aborted"
+}
+
+let releaseDocs =  BuildTask.create "ReleaseDocs" [buildDocs] {
+    let msg = sprintf "release docs for version %s?" stableVersionTag
+    if promptYesNo msg then
+        Shell.cleanDir "temp"
+        Git.CommandHelper.runSimpleGitCommand "." (sprintf "clone %s temp/gh-pages --depth 1 -b gh-pages" projectRepo) |> ignore
+        Shell.copyRecursive "output" "temp/gh-pages" true |> printfn "%A"
+        Git.CommandHelper.runSimpleGitCommand "temp/gh-pages" "add ." |> printfn "%s"
+        let cmd = sprintf """commit -a -m "Update generated documentation for version %s""" stableVersionTag
+        Git.CommandHelper.runSimpleGitCommand "temp/gh-pages" cmd |> printfn "%s"
+        Git.Branches.push "temp/gh-pages"
+    else failwith "aborted"
+}
+
+let prereleaseDocs =  BuildTask.create "PrereleaseDocs" [buildDocsPrerelease] {
+    let msg = sprintf "release docs for version %s?" prereleaseTag
+    if promptYesNo msg then
+        Shell.cleanDir "temp"
+        Git.CommandHelper.runSimpleGitCommand "." (sprintf "clone %s temp/gh-pages --depth 1 -b gh-pages" projectRepo) |> ignore
+        Shell.copyRecursive "output" "temp/gh-pages" true |> printfn "%A"
+        Git.CommandHelper.runSimpleGitCommand "temp/gh-pages" "add ." |> printfn "%s"
+        let cmd = sprintf """commit -a -m "Update generated documentation for version %s""" prereleaseTag
+        Git.CommandHelper.runSimpleGitCommand "temp/gh-pages" cmd |> printfn "%s"
+        Git.Branches.push "temp/gh-pages"
+    else failwith "aborted"
+}

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -1,0 +1,43 @@
+﻿module TestTasks
+
+open BlackFox.Fake
+open Fake.DotNet
+
+open ProjectInfo
+open BasicTasks
+
+let runTests = BuildTask.create "RunTests" [clean; build] {
+    testProjects
+    |> Seq.iter (fun testProject ->
+        Fake.DotNet.DotNet.test(fun testParams ->
+            {
+                testParams with
+                    Logger = Some "console;verbosity=detailed"
+                    Configuration = DotNet.BuildConfiguration.fromString configuration
+                    NoBuild = true
+            }
+        ) testProject
+    )
+}
+
+// to do: use this once we have actual tests
+let runTestsWithCodeCov = BuildTask.create "RunTestsWithCodeCov" [clean; build] {
+    let standardParams = Fake.DotNet.MSBuild.CliArguments.Create ()
+    testProjects
+    |> Seq.iter(fun testProject -> 
+        Fake.DotNet.DotNet.test(fun testParams ->
+            {
+                testParams with
+                    MSBuildParams = {
+                        standardParams with
+                            Properties = [
+                                "AltCover","true"
+                                "AltCoverCobertura","../../codeCov.xml"
+                                "AltCoverForce","true"
+                            ]
+                    };
+                    Logger = Some "console;verbosity=detailed"
+            }
+        ) testProject
+    )
+}

--- a/src/ISADotNet.QueryModel/Errors.fs
+++ b/src/ISADotNet.QueryModel/Errors.fs
@@ -9,6 +9,8 @@ module Errors =
     exception MissingFactorException            of Factor
     exception MissingCategoryException          of OntologyAnnotation
 
+    exception MissingOATextException            of OntologyAnnotation
+
     exception MissingProtocolException          of string
     exception MissingProtocolWithTypeException  of OntologyAnnotation
     exception ProtocolHasNoDescriptionException of string
@@ -31,6 +33,9 @@ module Errors =
 
     let missingCharacteristic (oa : OntologyAnnotation) =
         raise (MissingCharacteristicException(MaterialAttribute.create(CharacteristicType = oa)))
+
+    let missingOAText (oa : OntologyAnnotation) =
+        raise (MissingOATextException(oa))
 
 
     let missingValue (oa : OntologyAnnotation) =
@@ -57,6 +62,29 @@ module Errors =
     exception InvestigationHasNoPublicationsException
     exception InvestigationHasNoContactsException
     exception InvestigationHasNoStudiesException
+    exception InvestigationHasNoCommentsException
+
+    exception StudyHasNoIDException
+    exception StudyHasNoFileNameException
+    exception StudyHasNoIdentifierException
+    exception StudyHasNoTitleException
+    exception StudyHasNoDescriptionException
+    exception StudyHasNoSubmissionDateException
+    exception StudyHasNoPublicReleaseDateException
+    exception StudyHasNoPublicationsException
+    exception StudyHasNoContactsException
+    exception StudyHasNoDesignDescriptorsException
+    exception StudyHasNoProtocolsException
+    exception StudyHasNoMaterialsException
+    exception StudyHasNoProcessSequenceException
+    exception StudyHasNoAssaysException
+    exception StudyHasNoFactorsException
+    exception StudyHasNoCharacteristicCategoriesException
+    exception StudyHasNoUnitCategoriesException
+    exception StudyHasNoStudyHasNoCommentsExceptionException
+
+
+
 
     exception PersonHasNoIDException
     exception PersonHasNoLastNameException
@@ -69,3 +97,161 @@ module Errors =
     exception PersonHasNoAffiliationException
     exception PersonHasNoRolesException
     exception PersonHasNoCommentsException 
+
+module ErrorHandling = 
+
+    open Errors 
+    open ISADotNet.Builder
+
+    let tryMessageToStudyTransformation (processName : string) (e : exn) =
+
+        match e with
+        | :? MissingCategoryException as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddParameter (ProcessParameterValue.create(ProtocolParameter.create(ParameterName = exc.Data0)))
+                    ProcessTransformation.AddName processName
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingParameterException  as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddParameter (ProcessParameterValue.create(exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingCharacteristicException     as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddCharacteristic (MaterialAttributeValue.create(Category = exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingFactorException             as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddFactor (FactorValue.create(Category = exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+                                                                      
+        | :? MissingProtocolException as exc ->
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName exc.Data0]
+                    ProcessTransformation.AddName exc.Data0
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingProtocolWithTypeException   as exc ->                                    
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [
+                        ProtocolTransformation.AddName exc.Data0.NameText
+                        ProtocolTransformation.AddProtocolType exc.Data0
+                    ]
+                    ProcessTransformation.AddName exc.Data0.NameText
+                ]
+
+            StudyTransformation.AddProcess processTransformation
+            |> Option.Some
+        //| :? ProtocolHasNoDescriptionException  as exc -> [NoneRequired([message exc])]
+                                                                      
+        //| :? MissingValueException              as exc -> [NoneRequired([message exc])]
+        //| :? MissingUnitException               as exc -> [NoneRequired([message exc])]
+        //| :? NoSynonymInTargOntologyException   as exc -> [NoneRequired([message exc])]
+        | err -> None
+
+
+    let tryMessageToTransformation (processName : string) (e : exn) =
+
+        match e with
+        | :? MissingCategoryException as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddParameter (ProcessParameterValue.create(ProtocolParameter.create(ParameterName = exc.Data0)))
+                    ProcessTransformation.AddName processName
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingParameterException  as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddParameter (ProcessParameterValue.create(exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingCharacteristicException     as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddCharacteristic (MaterialAttributeValue.create(Category = exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingFactorException             as exc -> 
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                    ProcessTransformation.AddFactor (FactorValue.create(Category = exc.Data0))
+                    ProcessTransformation.AddName processName
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+                                                                      
+        | :? MissingProtocolException as exc ->
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [ProtocolTransformation.AddName exc.Data0]
+                    ProcessTransformation.AddName exc.Data0
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+        | :? MissingProtocolWithTypeException   as exc ->                                    
+            let processTransformation = 
+                [
+                    ProcessTransformation.AddProtocol [
+                        ProtocolTransformation.AddName exc.Data0.NameText
+                        ProtocolTransformation.AddProtocolType exc.Data0
+                    ]
+                    ProcessTransformation.AddName exc.Data0.NameText
+                ]
+
+            AssayTransformation.AddProcess processTransformation
+            |> Option.Some
+        //| :? ProtocolHasNoDescriptionException  as exc -> [NoneRequired([message exc])]
+                                                                      
+        //| :? MissingValueException              as exc -> [NoneRequired([message exc])]
+        //| :? MissingUnitException               as exc -> [NoneRequired([message exc])]
+        //| :? NoSynonymInTargOntologyException   as exc -> [NoneRequired([message exc])]
+        | err -> None
+
+    let getTransformations (processName : string) (es : exn list) =
+        es 
+        |> List.choose (tryMessageToTransformation processName)
+
+    let getStudyformations (processName : string) (es : exn list) =
+        es 
+        |> List.choose (tryMessageToStudyTransformation processName)

--- a/src/ISADotNet.QueryModel/Errors.fs
+++ b/src/ISADotNet.QueryModel/Errors.fs
@@ -1,4 +1,4 @@
-﻿namespace ISADotNet.QueryModel.Linq
+﻿namespace ISADotNet.QueryModel
 
 open ISADotNet
 
@@ -44,3 +44,28 @@ module Errors =
 
     let protocolHasNoDescription (name : string) =
         raise (ProtocolHasNoDescriptionException(name))
+
+
+    exception InvestigationHasNoIDException
+    exception InvestigationHasNoFileNameException
+    exception InvestigationHasNoIdentifierException
+    exception InvestigationHasNoTitleException
+    exception InvestigationHasNoDescriptionException
+    exception InvestigationHasNoSubmissionDateException
+    exception InvestigationHasNoPublicReleaseDateException
+    exception InvestigationHasNoOntologySourceReferencesException
+    exception InvestigationHasNoPublicationsException
+    exception InvestigationHasNoContactsException
+    exception InvestigationHasNoStudiesException
+
+    exception PersonHasNoIDException
+    exception PersonHasNoLastNameException
+    exception PersonHasNoFirstNameException
+    exception PersonHasNoMidInitialsException
+    exception PersonHasNoEMailException
+    exception PersonHasNoPhoneException
+    exception PersonHasNoFaxException
+    exception PersonHasNoAddressException
+    exception PersonHasNoAffiliationException
+    exception PersonHasNoRolesException
+    exception PersonHasNoCommentsException 

--- a/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
+++ b/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Errors.fs" />
     <Compile Include="Obo.fs" />
     <Compile Include="OntologyAnnotation.fs" />
     <Compile Include="Comment.fs" />
@@ -19,9 +20,9 @@
     <Compile Include="Sheet.fs" />
     <Compile Include="ProcessSequence.fs" />
     <Compile Include="Assay.fs" />
+    <Compile Include="Person.fs" />
     <Compile Include="Study.fs" />
     <Compile Include="Investigation.fs" />
-    <Compile Include="Linq\Errors.fs" />
     <Compile Include="Linq\Helpers.fs" />
     <Compile Include="Linq\QueryBuilder.fs" />
     <Compile Include="Linq\Spreadsheet.fs" />

--- a/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
+++ b/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Assay.fs" />
     <Compile Include="Study.fs" />
     <Compile Include="Investigation.fs" />
+    <Compile Include="Linq\Errors.fs" />
     <Compile Include="Linq\Helpers.fs" />
     <Compile Include="Linq\QueryBuilder.fs" />
     <Compile Include="Linq\Spreadsheet.fs" />
@@ -28,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet" Version="0.3.0-preview.2" />
+    <PackageReference Include="FsSpreadsheet" Version="0.3.0-preview.3" />
     <PackageReference Include="Swate.Api" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
+++ b/src/ISADotNet.QueryModel/ISADotNet.QueryModel.fsproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet" Version="0.3.0-preview.3" />
+    <PackageReference Include="FsSpreadsheet" Version="0.3.0" />
     <PackageReference Include="Swate.Api" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/ISADotNet.QueryModel/Investigation.fs
+++ b/src/ISADotNet.QueryModel/Investigation.fs
@@ -132,41 +132,41 @@ module Investigation =
 
     let fileName (i : QInvestigation) =
         match i.FileName with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoFileNameException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoFileNameException
     let identifier (i : QInvestigation) =
         match i.Identifier with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoIdentifierException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoIdentifierException
     let title (i : QInvestigation) =
         match i.Title with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoTitleException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoTitleException
     let description (i : QInvestigation) =
         match i.Description with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoDescriptionException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoDescriptionException
     let submissionDate (i : QInvestigation) =
         match i.SubmissionDate with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoSubmissionDateException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoSubmissionDateException
     let publicReleaseDate (i : QInvestigation) =
         match i.PublicReleaseDate with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoPublicReleaseDateException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoPublicReleaseDateException
     let ontologySourceReferences (i : QInvestigation) =
         match i.OntologySourceReferences with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoOntologySourceReferencesException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoOntologySourceReferencesException
     let publications (i : QInvestigation) =
         match i.Publications with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoPublicationsException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoPublicationsException
     let contacts (i : QInvestigation) =
         match i.Contacts with
-        | Some v -> Ok (v)
-        | None -> Error (InvestigationHasNoContactsException)
+        | Some v -> (v)
+        | None -> raise InvestigationHasNoContactsException
     let studies (i : QInvestigation) =
         match i.Studies with
-        | []  -> Error (InvestigationHasNoStudiesException)
-        | s -> Ok (s)
+        | []  -> raise InvestigationHasNoStudiesException
+        | s -> s

--- a/src/ISADotNet.QueryModel/Investigation.fs
+++ b/src/ISADotNet.QueryModel/Investigation.fs
@@ -125,3 +125,48 @@ type QInvestigation
     static member fromFile (path : string) = 
         File.ReadAllText path 
         |> QInvestigation.fromString
+
+module Investigation =
+
+    open Errors
+
+    let fileName (i : QInvestigation) =
+        match i.FileName with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoFileNameException)
+    let identifier (i : QInvestigation) =
+        match i.Identifier with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoIdentifierException)
+    let title (i : QInvestigation) =
+        match i.Title with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoTitleException)
+    let description (i : QInvestigation) =
+        match i.Description with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoDescriptionException)
+    let submissionDate (i : QInvestigation) =
+        match i.SubmissionDate with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoSubmissionDateException)
+    let publicReleaseDate (i : QInvestigation) =
+        match i.PublicReleaseDate with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoPublicReleaseDateException)
+    let ontologySourceReferences (i : QInvestigation) =
+        match i.OntologySourceReferences with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoOntologySourceReferencesException)
+    let publications (i : QInvestigation) =
+        match i.Publications with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoPublicationsException)
+    let contacts (i : QInvestigation) =
+        match i.Contacts with
+        | Some v -> Ok (v)
+        | None -> Error (InvestigationHasNoContactsException)
+    let studies (i : QInvestigation) =
+        match i.Studies with
+        | []  -> Error (InvestigationHasNoStudiesException)
+        | s -> Ok (s)

--- a/src/ISADotNet.QueryModel/Linq/Errors.fs
+++ b/src/ISADotNet.QueryModel/Linq/Errors.fs
@@ -1,0 +1,46 @@
+﻿namespace ISADotNet.QueryModel.Linq
+
+open ISADotNet
+
+module Errors =
+
+    exception MissingParameterException         of ProtocolParameter
+    exception MissingCharacteristicException    of MaterialAttribute
+    exception MissingFactorException            of Factor
+    exception MissingCategoryException          of OntologyAnnotation
+
+    exception MissingProtocolException          of string
+    exception MissingProtocolWithTypeException  of OntologyAnnotation
+    exception ProtocolHasNoDescriptionException of string
+
+    exception MissingValueException             of OntologyAnnotation
+    exception MissingUnitException              of OntologyAnnotation
+    exception NoSynonymInTargOntologyException  of OntologyAnnotation*string
+
+    exception FieldNotFilledException           of string
+
+
+    let missingCategory (oa : OntologyAnnotation) =
+        raise (MissingCategoryException(oa))
+
+    let missingFactor (oa : OntologyAnnotation) =
+        raise (MissingFactorException(Factor.create(FactorType = oa)))
+
+    let missingParameter (oa : OntologyAnnotation) =
+        raise (MissingParameterException(ProtocolParameter.create(ParameterName = oa)))
+
+    let missingCharacteristic (oa : OntologyAnnotation) =
+        raise (MissingCharacteristicException(MaterialAttribute.create(CharacteristicType = oa)))
+
+
+    let missingValue (oa : OntologyAnnotation) =
+        raise (MissingValueException(oa))
+
+    let noSynonymInTargetOntology (oa : OntologyAnnotation) (targetOnt : string) =
+        raise (NoSynonymInTargOntologyException(oa,targetOnt))
+
+    let missingProtocolWithType (oa : OntologyAnnotation) =
+        raise (MissingProtocolWithTypeException(oa))
+
+    let protocolHasNoDescription (name : string) =
+        raise (ProtocolHasNoDescriptionException(name))

--- a/src/ISADotNet.QueryModel/Linq/Spreadsheet.fs
+++ b/src/ISADotNet.QueryModel/Linq/Spreadsheet.fs
@@ -5,8 +5,11 @@ open System.Collections
 open Microsoft.FSharp.Linq.RuntimeHelpers
 open Microsoft.FSharp.Quotations.Patterns
 open FsSpreadsheet.DSL
+open Errors
 open ISADotNet.QueryModel
 open Helpers
+open ISADotNet
+open ISADotNet.Builder
 
 /// Should be opened for using ISA-Value querying DSL in combindation with FsSpreadsheet DSL.
 module Spreadsheet =
@@ -46,7 +49,19 @@ module Spreadsheet =
                     SheetEntity.ok cell         
                 with
                 //| err when this.IsOptional -> MissingOptional([this.FormatError err])
-                | err  -> NoneRequired([this.FormatError err])               
+                | :? MissingCategoryException           as exc -> NoneRequired([message exc])
+                | :? MissingParameterException          as exc -> NoneRequired([message exc])
+                | :? MissingCharacteristicException     as exc -> NoneRequired([message exc])
+                | :? MissingFactorException             as exc -> NoneRequired([message exc])
+
+                | :? MissingProtocolException           as exc -> NoneRequired([message exc])
+                | :? MissingProtocolWithTypeException   as exc -> NoneRequired([message exc])
+                | :? ProtocolHasNoDescriptionException  as exc -> NoneRequired([message exc])
+
+                | :? MissingValueException              as exc -> NoneRequired([message exc])
+                | :? MissingUnitException               as exc -> NoneRequired([message exc])
+                | :? NoSynonymInTargOntologyException   as exc -> NoneRequired([message exc])
+                | err -> NoneRequired([message err])            
 
     [<AutoOpen>]
     module OptionCellExtensions =
@@ -67,8 +82,20 @@ module Spreadsheet =
                         let cell = CellElement(value,None)
                         SheetEntity.ok cell 
                     with 
-                    | err -> NoneOptional([this.FormatError err])   
-                | Result.Error err -> NoneOptional([this.FormatError err])   
+                    | :? MissingCategoryException           as exc -> NoneOptional([message exc])
+                    | :? MissingParameterException          as exc -> NoneOptional([message exc])
+                    | :? MissingCharacteristicException     as exc -> NoneOptional([message exc])
+                    | :? MissingFactorException             as exc -> NoneOptional([message exc])
+
+                    | :? MissingProtocolException           as exc -> NoneOptional([message exc])
+                    | :? MissingProtocolWithTypeException   as exc -> NoneOptional([message exc])
+                    | :? ProtocolHasNoDescriptionException  as exc -> NoneOptional([message exc])
+
+                    | :? MissingValueException              as exc -> NoneOptional([message exc])
+                    | :? MissingUnitException               as exc -> NoneOptional([message exc])
+                    | :? NoSynonymInTargOntologyException   as exc -> NoneOptional([message exc]) 
+                    | err -> NoneOptional([message err])   
+                | Result.Error err -> NoneOptional([message (this.FormatError err)])    
        
     [<AutoOpen>]
     module RequiredCellExtensions =
@@ -89,8 +116,20 @@ module Spreadsheet =
                         let cell = CellElement(value,None)
                         SheetEntity.ok cell 
                     with 
-                    | err -> NoneRequired([this.FormatError err])   
-                | Result.Error err -> NoneRequired([this.FormatError err])   
+                    | :? MissingCategoryException           as exc -> NoneRequired([message exc])
+                    | :? MissingParameterException          as exc -> NoneRequired([message exc])
+                    | :? MissingCharacteristicException     as exc -> NoneRequired([message exc])
+                    | :? MissingFactorException             as exc -> NoneRequired([message exc])
+
+                    | :? MissingProtocolException           as exc -> NoneRequired([message exc])
+                    | :? MissingProtocolWithTypeException   as exc -> NoneRequired([message exc])
+                    | :? ProtocolHasNoDescriptionException  as exc -> NoneRequired([message exc])
+
+                    | :? MissingValueException              as exc -> NoneRequired([message exc])
+                    | :? MissingUnitException               as exc -> NoneRequired([message exc])
+                    | :? NoSynonymInTargOntologyException   as exc -> NoneRequired([message exc])
+                    | err -> NoneRequired([message err])   
+                | Result.Error err -> NoneRequired([message (this.FormatError err)])
 
 
     [<AutoOpen>]
@@ -107,7 +146,19 @@ module Spreadsheet =
                         SheetEntity.ok cell)
                     |> Seq.toList
                 with
-                | err -> [NoneRequired([this.FormatError err])]
+                | :? MissingCategoryException           as exc -> [NoneRequired([message exc])]
+                | :? MissingParameterException          as exc -> [NoneRequired([message exc])]
+                | :? MissingCharacteristicException     as exc -> [NoneRequired([message exc])]
+                | :? MissingFactorException             as exc -> [NoneRequired([message exc])]
+                                                                  
+                | :? MissingProtocolException           as exc -> [NoneRequired([message exc])]
+                | :? MissingProtocolWithTypeException   as exc -> [NoneRequired([message exc])]
+                | :? ProtocolHasNoDescriptionException  as exc -> [NoneRequired([message exc])]
+                                                                  
+                | :? MissingValueException              as exc -> [NoneRequired([message exc])]
+                | :? MissingUnitException               as exc -> [NoneRequired([message exc])]
+                | :? NoSynonymInTargOntologyException   as exc -> [NoneRequired([message exc])]
+                | err -> [NoneRequired([message err])]  
 
     [<AutoOpen>]
     module OptionEnumerableExtensions =
@@ -131,8 +182,20 @@ module Spreadsheet =
                             SheetEntity.ok cell) 
                         |> Seq.toList
                     with 
-                    | err -> [NoneOptional([this.FormatError err])]   
-                | Result.Error err -> [NoneOptional([this.FormatError err])]   
+                    | :? MissingCategoryException           as exc -> [NoneOptional([message exc])]
+                    | :? MissingParameterException          as exc -> [NoneOptional([message exc])]
+                    | :? MissingCharacteristicException     as exc -> [NoneOptional([message exc])]
+                    | :? MissingFactorException             as exc -> [NoneOptional([message exc])]
+                                                                      
+                    | :? MissingProtocolException           as exc -> [NoneOptional([message exc])]
+                    | :? MissingProtocolWithTypeException   as exc -> [NoneOptional([message exc])]
+                    | :? ProtocolHasNoDescriptionException  as exc -> [NoneOptional([message exc])]
+                                                                      
+                    | :? MissingValueException              as exc -> [NoneOptional([message exc])]
+                    | :? MissingUnitException               as exc -> [NoneOptional([message exc])]
+                    | :? NoSynonymInTargOntologyException   as exc -> [NoneOptional([message exc])]
+                    | err -> [NoneOptional([message err])]   
+                | Result.Error err -> [NoneOptional([message (this.FormatError err)])]    
 
 
     [<AutoOpen>]
@@ -157,8 +220,102 @@ module Spreadsheet =
                             SheetEntity.ok cell)        
                         |> Seq.toList
                     with 
-                    | err -> [NoneRequired([this.FormatError err])]   
-                | Result.Error err -> [NoneRequired([this.FormatError err])]   
+                    | :? MissingCategoryException           as exc -> [NoneRequired([message exc])]
+                    | :? MissingParameterException          as exc -> [NoneRequired([message exc])]
+                    | :? MissingCharacteristicException     as exc -> [NoneRequired([message exc])]
+                    | :? MissingFactorException             as exc -> [NoneRequired([message exc])]
+                                                                      
+                    | :? MissingProtocolException           as exc -> [NoneRequired([message exc])]
+                    | :? MissingProtocolWithTypeException   as exc -> [NoneRequired([message exc])]
+                    | :? ProtocolHasNoDescriptionException  as exc -> [NoneRequired([message exc])]
+                                                                      
+                    | :? MissingValueException              as exc -> [NoneRequired([message exc])]
+                    | :? MissingUnitException               as exc -> [NoneRequired([message exc])]
+                    | :? NoSynonymInTargOntologyException   as exc -> [NoneRequired([message exc])]
+                    | err -> [NoneRequired([message err])]   
+                | Result.Error err -> [NoneRequired([message (this.FormatError err)])]   
 
     /// Computation expression for querying ISA values for consumption of FsSpreadsheet DSL.
     let cells = CellBuilder()
+
+    module ErrorHandling = 
+
+        let tryMessageToTransformation (processName : string) (ms : Message) =
+
+            ms.TryException()
+            |> Option.bind (fun e ->
+                match e with
+                | :? MissingCategoryException as exc -> 
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                            ProcessTransformation.AddParameter (ProcessParameterValue.create(ProtocolParameter.create(ParameterName = exc.Data0)))
+                            ProcessTransformation.AddName processName
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                | :? MissingParameterException  as exc -> 
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                            ProcessTransformation.AddParameter (ProcessParameterValue.create(exc.Data0))
+                            ProcessTransformation.AddName processName
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                | :? MissingCharacteristicException     as exc -> 
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                            ProcessTransformation.AddCharacteristic (MaterialAttributeValue.create(Category = exc.Data0))
+                            ProcessTransformation.AddName processName
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                | :? MissingFactorException             as exc -> 
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [ProtocolTransformation.AddName processName]
+                            ProcessTransformation.AddFactor (FactorValue.create(Category = exc.Data0))
+                            ProcessTransformation.AddName processName
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                                                                      
+                | :? MissingProtocolException as exc ->
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [ProtocolTransformation.AddName exc.Data0]
+                            ProcessTransformation.AddName exc.Data0
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                | :? MissingProtocolWithTypeException   as exc ->                                    
+                    let processTransformation = 
+                        [
+                            ProcessTransformation.AddProtocol [
+                                ProtocolTransformation.AddName exc.Data0.NameText
+                                ProtocolTransformation.AddProtocolType exc.Data0
+                            ]
+                            ProcessTransformation.AddName exc.Data0.NameText
+                        ]
+
+                    AssayTransformation.AddProcess processTransformation
+                    |> Option.Some
+                //| :? ProtocolHasNoDescriptionException  as exc -> [NoneRequired([message exc])]
+                                                                      
+                //| :? MissingValueException              as exc -> [NoneRequired([message exc])]
+                //| :? MissingUnitException               as exc -> [NoneRequired([message exc])]
+                //| :? NoSynonymInTargOntologyException   as exc -> [NoneRequired([message exc])]
+                | err -> None
+    
+        )
+
+        let getTransformations  (processName : string) (mss : Message list) =
+            mss 
+            |> List.choose (tryMessageToTransformation processName)

--- a/src/ISADotNet.QueryModel/Linq/Spreadsheet.fs
+++ b/src/ISADotNet.QueryModel/Linq/Spreadsheet.fs
@@ -5,8 +5,8 @@ open System.Collections
 open Microsoft.FSharp.Linq.RuntimeHelpers
 open Microsoft.FSharp.Quotations.Patterns
 open FsSpreadsheet.DSL
-open Errors
 open ISADotNet.QueryModel
+open Errors
 open Helpers
 open ISADotNet
 open ISADotNet.Builder

--- a/src/ISADotNet.QueryModel/Person.fs
+++ b/src/ISADotNet.QueryModel/Person.fs
@@ -1,0 +1,50 @@
+﻿namespace ISADotNet.QueryModel
+open ISADotNet
+module Person = 
+
+    open Errors
+
+    let id (p : Person) =
+        match p.ID with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoIDException)
+    let lastName (p : Person) =
+        match p.LastName with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoLastNameException)
+    let firstName (p : Person) =
+        match p.FirstName with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoFirstNameException)
+    let midInitials (p : Person) =
+        match p.MidInitials with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoMidInitialsException)
+    let email (p : Person) =
+        match p.EMail with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoEMailException)
+    let phone (p : Person) =
+        match p.Phone with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoPhoneException)
+    let fax (p : Person) =
+        match p.Fax with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoFaxException)
+    let address (p : Person) =
+        match p.Address with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoAddressException)
+    let affiliation (p : Person) =
+        match p.Affiliation with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoAffiliationException)
+    let roles (p : Person) =
+        match p.Roles with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoRolesException)
+    let comments (p : Person) =
+        match p.Comments with
+        | Some v -> Ok v
+        | None -> Error (PersonHasNoCommentsException) 

--- a/src/ISADotNet.QueryModel/Person.fs
+++ b/src/ISADotNet.QueryModel/Person.fs
@@ -6,45 +6,45 @@ module Person =
 
     let id (p : Person) =
         match p.ID with
-        | Some v -> Ok v
-        | None -> Error (PersonHasNoIDException)
+        | Some v -> v
+        | None -> raise PersonHasNoIDException
     let lastName (p : Person) =
         match p.LastName with
-        | Some v -> Ok v
-        | None -> Error (PersonHasNoLastNameException)
+        | Some v -> v
+        | None -> raise PersonHasNoLastNameException
     let firstName (p : Person) =
         match p.FirstName with
-        | Some v -> Ok v
-        | None -> Error (PersonHasNoFirstNameException)
+        | Some v -> v
+        | None -> raise PersonHasNoFirstNameException
     let midInitials (p : Person) =
         match p.MidInitials with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoMidInitialsException)
+        | None -> raise PersonHasNoMidInitialsException
     let email (p : Person) =
         match p.EMail with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoEMailException)
+        | None -> raise PersonHasNoEMailException
     let phone (p : Person) =
         match p.Phone with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoPhoneException)
+        | None -> raise PersonHasNoPhoneException
     let fax (p : Person) =
         match p.Fax with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoFaxException)
+        | None -> raise PersonHasNoFaxException
     let address (p : Person) =
         match p.Address with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoAddressException)
+        | None -> raise PersonHasNoAddressException
     let affiliation (p : Person) =
         match p.Affiliation with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoAffiliationException)
+        | None -> raise PersonHasNoAffiliationException
     let roles (p : Person) =
         match p.Roles with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoRolesException)
+        | None -> raise PersonHasNoRolesException
     let comments (p : Person) =
         match p.Comments with
         | Some v -> Ok v
-        | None -> Error (PersonHasNoCommentsException) 
+        | None -> raise PersonHasNoCommentsException

--- a/src/ISADotNet.QueryModel/ProcessSequence.fs
+++ b/src/ISADotNet.QueryModel/ProcessSequence.fs
@@ -51,11 +51,13 @@ type QProcessSequence (sheets : QSheet list) =
                     (x.Name.Value |> Process.decomposeName |> fst)
                 elif x.ExecutesProtocol.IsSome && x.ExecutesProtocol.Value.Name.IsSome then
                     x.ExecutesProtocol.Value.Name.Value 
-                else
-                    // Data Stewards use '_' as seperator to distinguish between protocol template types.
-                    // Exmp. 1SPL01_plants, in these cases we need to find the last '_' char and remove from that index.
+                elif x.Name.Value.Contains "_" then
                     let lastUnderScoreIndex = x.Name.Value.LastIndexOf '_'
                     x.Name.Value.Remove lastUnderScoreIndex
+                else
+                    x.Name.Value
+                    // Data Stewards use '_' as seperator to distinguish between protocol template types.
+                    // Exmp. 1SPL01_plants, in these cases we need to find the last '_' char and remove from that index.                   
             )
             |> List.map (fun (name,processes) -> QSheet.fromProcesses name processes)
             |> updateNodes

--- a/src/ISADotNet.QueryModel/Row.fs
+++ b/src/ISADotNet.QueryModel/Row.fs
@@ -48,7 +48,7 @@ type QRow =
 
     static member fromProcess (proc : Process) : QRow list =
         let parameterValues = proc.ParameterValues |> Option.defaultValue []
-        List.zip proc.Inputs.Value proc.Outputs.Value
+        List.zip (proc.Inputs |> Option.defaultValue [ProcessInput.Default]) (proc.Outputs |> Option.defaultValue [ProcessOutput.Default])
         |> List.groupBy (fun (i,o) -> i.GetName,o.GetName)
         |> List.map (fun ((inputName,outputName),ios) ->
             

--- a/src/ISADotNet.QueryModel/Study.fs
+++ b/src/ISADotNet.QueryModel/Study.fs
@@ -109,3 +109,75 @@ type QStudy
     static member fromFile (path : string) = 
         File.ReadAllText path 
         |> QStudy.fromString
+
+module Study =
+
+    open Errors
+
+    let fileName (s : QStudy) = 
+        match s.FileName with
+        | Some v -> v
+        | None -> raise StudyHasNoFileNameException
+    let identifier (s : QStudy) = 
+        match s.Identifier with
+        | Some v -> v
+        | None -> raise StudyHasNoIdentifierException
+    let title (s : QStudy) = 
+        match s.Title with
+        | Some v -> v
+        | None -> raise StudyHasNoTitleException
+    let description (s : QStudy) = 
+        match s.Description with
+        | Some v -> v
+        | None -> raise StudyHasNoDescriptionException
+    let submissionDate (s : QStudy) = 
+        match s.SubmissionDate with
+        | Some v -> v
+        | None -> raise StudyHasNoSubmissionDateException
+    let publicReleaseDate (s : QStudy) = 
+        match s.PublicReleaseDate with
+        | Some v -> v
+        | None -> raise StudyHasNoPublicReleaseDateException
+    let publications (s : QStudy) = 
+        match s.Publications with
+        | Some v -> v
+        | None -> raise StudyHasNoPublicationsException
+    let contacts (s : QStudy) = 
+        match s.Contacts with
+        | Some v -> v
+        | None -> raise StudyHasNoContactsException
+    let designDescriptors (s : QStudy) = 
+        match s.StudyDesignDescriptors with
+        | Some v -> v
+        | None -> raise StudyHasNoDesignDescriptorsException
+    let protocols (s : QStudy) = 
+        match s.Protocols with
+        | [] -> raise StudyHasNoProtocolsException
+        | v -> v
+    //let materials (s : QStudy) = 
+    //    match s.Materials with
+    //    | Some v -> v
+    //    | None -> raise StudyHasNoMaterialsException
+    //let fileName (s : QStudy) = 
+    //    match s.Protocols with
+    //    | Some v -> v
+    //    | None -> raise StudyHasNoProcessSequenceException
+    let assays (s : QStudy) = 
+        match s.Assays with
+        | [] -> raise StudyHasNoAssaysException
+        | v -> v
+    //let factors (s : QStudy) = 
+    //    let f = s.Factors()
+    //    if f.IsEmpty then raise StudyHasNoFactorsException
+    //let CharacteristicCategories (s : QStudy) = 
+    //    match s.FileName with
+    //    | Some v -> v
+    //    | None -> raise StudyHasNoCharacteristicCategoriesException
+    //let fileName (s : QStudy) = 
+    //    match s.FileName with
+    //    | Some v -> v
+    //    | None -> raise StudyHasNoUnitCategoriesException
+    //let fileName (s : QStudy) = 
+    //    match s.FileName with
+    //    | Some v -> v
+    //    | None -> raise StudyHasNoStudyHasNoCommentsExceptionException

--- a/src/ISADotNet.Validation/ISADotNet.Validation.fsproj
+++ b/src/ISADotNet.Validation/ISADotNet.Validation.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/ISADotNet.XLSX/ISADotNet.XLSX.fsproj
+++ b/src/ISADotNet.XLSX/ISADotNet.XLSX.fsproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet.ExcelIO" Version="0.3.0-preview.1" />
+    <PackageReference Include="FsSpreadsheet.ExcelIO" Version="0.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ISADotNet/API/Assay.fs
+++ b/src/ISADotNet/API/Assay.fs
@@ -287,3 +287,9 @@ module Assay =
             }
         with
         | err -> failwithf $"Could not update assay {assay.FileName}: \n{err.Message}"
+
+    let updateProtocols (protocols : Protocol list) (assay : Assay) =
+        try
+            mapProcesses (ProcessSequence.updateProtocols protocols) assay
+        with
+        | err -> failwithf $"Could not update assay protocols {assay.FileName}: \n{err.Message}"

--- a/src/ISADotNet/API/Process.fs
+++ b/src/ISADotNet/API/Process.fs
@@ -381,12 +381,14 @@ module Process =
         (p.Inputs |> Option.defaultValue [] |> List.choose ProcessInput.tryMaterial)
         |> List.distinct
 
-    //let tryGetCharacteristicValuesOfInputBy (predicate : ProcessInput -> bool) (p : Process) =
-    //    match p.Inputs with
-    //    | Some is -> 
-    //        is
-    //        |> List.choose
-    //    | None -> None
+    let updateProtocol (referenceProtocols : Protocol list) (p : Process) =
+        match p.ExecutesProtocol with
+        | Some protocol when protocol.Name.IsSome ->
+            match referenceProtocols |> List.tryFind (fun prot -> prot.Name.Value = (protocol.Name |> Option.defaultValue "")) with
+            | Some refProtocol ->
+                {p with ExecutesProtocol = Some (Update.UpdateByExistingAppendLists.updateRecordType protocol refProtocol)}
+            | _ -> p
+        | _ -> p
 
 
 module ProcessSequence = 
@@ -557,3 +559,7 @@ module ProcessSequence =
         processSequence
         |> List.collect Process.getMaterials
         |> List.distinct
+
+    let updateProtocols (protocols : Protocol list) (processSequence : Process list) =
+        processSequence
+        |> List.map (Process.updateProtocol protocols)

--- a/src/ISADotNet/API/Study.fs
+++ b/src/ISADotNet/API/Study.fs
@@ -260,13 +260,15 @@ module Study =
 
     let update (study : Study) =
         try
+            let protocols = getProtocols study 
             {study with 
                         Materials  = getMaterials study |> Option.fromValueWithDefault StudyMaterials.empty
-                        Assays = study.Assays |> Option.map (List.map Assay.update)
-                        Protocols = getProtocols study |> Option.fromValueWithDefault []
+                        Assays = study.Assays |> Option.map (List.map (Assay.update >> Assay.updateProtocols protocols))
+                        Protocols = protocols |> Option.fromValueWithDefault []
                         Factors = getFactors study |> Option.fromValueWithDefault []
                         CharacteristicCategories = getCharacteristics study |> Option.fromValueWithDefault []
                         UnitCategories = getUnitCategories study |> Option.fromValueWithDefault []
+                        ProcessSequence = study.ProcessSequence |> Option.map (ProcessSequence.updateProtocols protocols)
             }
         with
         | err -> failwithf $"Could not update study {study.Identifier}: \n{err.Message}"

--- a/src/ISADotNet/API/Study.fs
+++ b/src/ISADotNet/API/Study.fs
@@ -219,8 +219,8 @@ module Study =
             match study.Materials with
             | Some mat -> mat.Sources |> Option.defaultValue []
             | None -> []
-        Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Source) -> s.Name) assaysSources processSequenceSources
-        |> Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Source) -> s.Name) studySources
+        Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Source) -> s.Name |> Option.defaultValue "") assaysSources processSequenceSources
+        |> Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Source) -> s.Name |> Option.defaultValue "") studySources
 
     /// Returns sources of the study
     let getSamples (study : Study) =
@@ -234,8 +234,8 @@ module Study =
             match study.Materials with
             | Some mat -> mat.Samples |> Option.defaultValue []
             | None -> []
-        Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Sample) -> s.Name) assaysSamples processSequenceSamples
-        |> Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Sample) -> s.Name) studySamples
+        Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Sample) -> s.Name |> Option.defaultValue "") assaysSamples processSequenceSamples
+        |> Update.mergeUpdateLists UpdateByExistingAppendLists (fun (s : Sample) -> s.Name |> Option.defaultValue "") studySamples
 
     /// Returns materials of the study
     let getMaterials (study : Study) =

--- a/src/ISADotNet/Builder/AssayBuilder.fs
+++ b/src/ISADotNet/Builder/AssayBuilder.fs
@@ -1,0 +1,2 @@
+﻿module AssayBuilder
+

--- a/src/ISADotNet/Builder/ProcessBuilder.fs
+++ b/src/ISADotNet/Builder/ProcessBuilder.fs
@@ -1,0 +1,2 @@
+﻿module ProcessBuilder
+

--- a/src/ISADotNet/Builder/Transform.fs
+++ b/src/ISADotNet/Builder/Transform.fs
@@ -1,0 +1,8 @@
+﻿namespace ISADotNet.Builder
+
+open ISADotNet
+
+//module Transform =
+    
+//    let transformProtocol (transformations : ProtocolTransformation list) (p : Protocol) =
+        

--- a/src/ISADotNet/Builder/Types.fs
+++ b/src/ISADotNet/Builder/Types.fs
@@ -1,0 +1,127 @@
+﻿namespace ISADotNet.Builder
+
+open ISADotNet
+
+type ProtocolTransformation =
+    
+    | AddName of string
+    | AddProtocolType of OntologyAnnotation
+    | AddDescription of string
+
+    member this.Transform(p : Protocol) =
+        match this with
+        | AddName n -> 
+            {p with Name = Some n}
+        | AddProtocolType t -> 
+            {p with ProtocolType = Some t}
+        | AddDescription d -> 
+            {p with Description = Some d}
+
+    member this.Equals(p : Protocol) =
+        match this,p.Name with
+        | AddName n, Some n' when n = n'-> 
+            true
+        | _ -> false
+
+type ProcessTransformation = 
+
+    | AddName of string
+
+    | AddParameter of ProcessParameterValue
+    | AddCharacteristic of MaterialAttributeValue
+    | AddFactor of FactorValue
+
+    //| RemoveParameter of ProcessParameterValue
+    //| RemoveCharacteristic of MaterialAttributeValue
+    //| RemoveFactor of FactorValue
+
+    //| TransformProtocol of ProtocolTransformation list
+    | AddProtocol of ProtocolTransformation list
+
+    member this.Transform(p : Process) =
+        match this with
+        | AddName n -> 
+            {p with Name = Some n}
+        | AddParameter pv -> 
+            let parameterValues = 
+                (p.ParameterValues |> Option.defaultValue []) @ [pv]
+            let protocol = 
+                let pro = p.ExecutesProtocol |> Option.defaultValue Protocol.empty
+                {pro with Parameters = Some ((pro.Parameters |> Option.defaultValue []) @ [pv.Category.Value])}
+            {p with 
+                ParameterValues = Some parameterValues
+                ExecutesProtocol = Some protocol
+                }
+        | AddCharacteristic c -> 
+            let inputs = 
+                p.Inputs 
+                |> Option.map (fun i -> 
+                    //Add characteristic
+                    //API.ProcessInput.addCharacteristics c i
+                    i
+                )
+            {p with Inputs = inputs}
+        | AddFactor f ->
+            let outputs = 
+                p.Outputs 
+                |> Option.map (fun i -> 
+                    //Add characteristic
+                    //API.ProcessInput.addCharacteristics c i
+                    i
+                )
+            {p with Outputs = outputs}
+        //| TransformProtocol of ProtocolTransformation list
+        | AddProtocol pts ->
+            let protocol = 
+                p.ExecutesProtocol 
+                |> Option.defaultValue Protocol.empty
+                |> fun pro -> 
+                    pts
+                    |> List.fold (fun pro trans -> trans.Transform(pro)) pro 
+            {p with ExecutesProtocol = Some protocol}
+
+    member this.Equals(p : Process) =
+        match this,p.Name with
+        | AddName n, Some n' when n = n'-> 
+            true
+        | _ -> false
+
+type AssayTransformation = 
+    
+    | AddParameter of ProcessParameterValue
+    | AddCharacteristic of MaterialAttributeValue
+    | AddFactor of FactorValue
+
+    //| RemoveParameter of ProcessParameterValue
+    //| RemoveCharacteristic of MaterialAttributeValue
+    //| RemoveFactor of FactorValue
+
+    | AddProcess of ProcessTransformation list
+
+    member this.Transform(a : Assay) = 
+        match this with
+        //| AddParameter of ProcessParameterValue
+        //| AddCharacteristic of MaterialAttributeValue
+        //| AddFactor of FactorValue
+        | AddProcess pts -> 
+            let processes = a.ProcessSequence |> Option.defaultValue []
+            let processes' = 
+                if processes |> List.exists (fun p -> pts |> List.exists (fun trans -> trans.Equals p)) then
+                    processes |> List.map (fun p ->
+                        if pts |> List.exists (fun trans -> trans.Equals p) then
+                            pts
+                            |> List.fold (fun p trans -> trans.Transform(p)) p
+                        else p
+                    )
+                else 
+                    let newProcess = 
+                        pts
+                        |> List.fold (fun p trans -> trans.Transform(p)) Process.empty
+                    processes @ [newProcess]
+            {a with ProcessSequence = Some processes'}
+
+    //member this.Equals(A : Assay) =
+    //    match this,a.File with
+    //    | AddName n, Some n' when n = n'-> 
+    //        true
+    //    | _ -> false

--- a/src/ISADotNet/DataModel/Ontology.fs
+++ b/src/ISADotNet/DataModel/Ontology.fs
@@ -67,6 +67,16 @@ type OntologyAnnotation =
         )
         |> Option.defaultValue ""
 
+    /// Returns the name of the ontology as string
+    member this.TryNameText =
+        this.Name
+        |> Option.map (fun av ->
+            match av with
+            | AnnotationValue.Text s  -> s
+            | AnnotationValue.Float f -> string f
+            | AnnotationValue.Int i   -> string i
+        )
+
     /// Returns the term source of the ontology as string
     member this.TermSourceREFString =       
         this.TermSourceREF

--- a/src/ISADotNet/DataModel/Process.fs
+++ b/src/ISADotNet/DataModel/Process.fs
@@ -88,7 +88,7 @@ type ProcessInput =
     | [<SerializationOrder(1)>] Sample of Sample
     | [<SerializationOrder(1)>] Data of Data
     | [<SerializationOrder(1)>] Material of Material 
-    
+
     member this.TryGetName =
         match this with
         | ProcessInput.Sample s     -> s.Name
@@ -99,6 +99,8 @@ type ProcessInput =
     member this.GetName =
         this.TryGetName
         |> Option.defaultValue ""
+
+    static member Default = Source (Source.empty)
 
     interface IISAPrintable with
         member this.Print() = 
@@ -127,6 +129,7 @@ type ProcessOutput =
         this.TryGetName
         |> Option.defaultValue ""
 
+    static member Default = Sample (Sample.empty)
 
     interface IISAPrintable with
         member this.Print() = 

--- a/src/ISADotNet/ISADotNet.fsproj
+++ b/src/ISADotNet/ISADotNet.fsproj
@@ -57,9 +57,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
-    <PackageReference Include="FSharp.SystemTextJson" Version="0.19.13" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0-preview.1.23110.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0-preview.1.23110.8" />
+    <PackageReference Include="FSharp.SystemTextJson" Version="1.1.23" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/ISADotNet/ISADotNet.fsproj
+++ b/src/ISADotNet/ISADotNet.fsproj
@@ -49,6 +49,10 @@
     <Compile Include="JsonIO\Assay.fs" />
     <Compile Include="JsonIO\Study.fs" />
     <Compile Include="JsonIO\Investigation.fs" />
+    <Compile Include="Builder\Types.fs" />
+    <Compile Include="Builder\ProcessBuilder.fs" />
+    <Compile Include="Builder\AssayBuilder.fs" />
+    <Compile Include="Builder\Transform.fs" />
     <Compile Include="ValueIndex.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
- Added simple transformer types 
   These transformers are basically directives for how to change and add values of properties of isa values. 
- Added concise error messages for Linq value querying
   More concise error messages were added when Linq querying fails. These tell the user what fields, protocols or values were missing
- In combination:
   Transformer directives can be created from the error messages. This allows automatic write-back of fields into the ISA-objects that were missing when querying